### PR TITLE
Ingestion of MQTT messages.

### DIFF
--- a/server/src/ingestion.rs
+++ b/server/src/ingestion.rs
@@ -41,7 +41,7 @@ impl Ingestor {
     /// Create a broker client, subscribe to the topics and start ingesting messages.
     pub fn start(self) {
         println!("Creating MQTT broker client.");
-        let mut client = create_client(self.broker, self.client_id);
+        let mut client = self.create_client();
 
         if let Err(err) = block_on(async {
             let mut stream = subscribe_to_broker(&mut client, self.topics, self.qos).await;
@@ -54,21 +54,19 @@ impl Ingestor {
             eprintln!("{}", err);
         }
     }
-}
 
-/// Create a broker client with the given broker URI and client ID.
-fn create_client(broker: &str, client_id: &str) -> AsyncClient {
-    let create_options = mqtt::CreateOptionsBuilder::new()
-        .server_uri(broker)
-        .client_id(client_id)
-        .finalize();
+    /// Create a broker client with the given broker URI and client ID.
+    fn create_client(&self) -> AsyncClient {
+        let create_options = mqtt::CreateOptionsBuilder::new()
+            .server_uri(self.broker)
+            .client_id(self.client_id)
+            .finalize();
 
-    let mut client = mqtt::AsyncClient::new(create_options).unwrap_or_else(|e| {
-        eprintln!("Error creating the client: {:?}", e);
-        process::exit(1);
-    });
-
-    client
+        mqtt::AsyncClient::new(create_options).unwrap_or_else(|e| {
+            eprintln!("Error creating the client: {:?}", e);
+            process::exit(1);
+        })
+    }
 }
 
 /// Make the connection to the broker and subscribe to the specified topics.

--- a/server/src/ingestion.rs
+++ b/server/src/ingestion.rs
@@ -1,0 +1,28 @@
+//! Module containing support for data ingestion from an MQTT broker.
+//!
+//! The connection settings of the ingestor are controlled through the broker, client, topics,
+//! and qos fields. Note that the client ID should be unique.
+//!
+//! To use the ingestor, first create the client, then use the created client to connect to the
+//! the broker and subscribe to the specific topics. Connecting returns a message stream that
+//! can be looped over to ingest the messages that are published to the topics.
+//!
+
+/* Copyright 2021 The MiniModelarDB Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub struct Ingestor {
+
+}

--- a/server/src/ingestion.rs
+++ b/server/src/ingestion.rs
@@ -47,7 +47,7 @@ impl Ingestor {
 
         if let Err(err) = block_on(async {
             let mut stream = subscribe_to_broker(&mut client, self.topics, self.qos).await;
-            ingest_messages(&mut stream, &mut client, compress_callback);
+            ingest_messages(&mut stream, &mut client, compress_callback).await;
 
             Ok::<(), mqtt::Error>(())
         }) {
@@ -56,6 +56,7 @@ impl Ingestor {
     }
 }
 
+/** Private Functions **/
 /// Create a broker client with the given broker URI and client ID.
 fn create_client(broker: &str, client_id: &str) -> AsyncClient {
     let create_options = mqtt::CreateOptionsBuilder::new()
@@ -106,7 +107,7 @@ async fn ingest_messages(
     while let Some(msg_opt) = stream.next().await {
         if let Some(msg) = msg_opt {
             // TODO: Currently the messages are just printed. Actually save the messages to a file or in memory.
-            println!("{}", msg);
+            compress_callback(msg)
         } else {
             // A "None" means we were disconnected. Try to reconnect...
             println!("Lost connection. Attempting reconnect.");

--- a/server/src/ingestion.rs
+++ b/server/src/ingestion.rs
@@ -24,8 +24,8 @@
  */
 use futures::{executor::block_on, stream::StreamExt};
 use paho_mqtt as mqtt;
-use std::{process, time::Duration};
 use paho_mqtt::{AsyncClient, AsyncReceiver, Message};
+use std::{process, time::Duration};
 
 pub struct Ingestor {
     broker: &'static str,
@@ -53,7 +53,11 @@ fn create_client(broker: &str, client_id: &str) -> AsyncClient {
 }
 
 /// Make the connection to the broker and subscribe to the specified topics.
-fn subscribe_to_broker(client: &mut AsyncClient, topics: &[&str], qos: &[i32]) -> AsyncReceiver<Option<Message>> {
+fn subscribe_to_broker(
+    client: &mut AsyncClient,
+    topics: &[&str],
+    qos: &[i32],
+) -> AsyncReceiver<Option<Message>> {
     // Get message stream before connecting since messages can arrive as soon as the connection is made.
     let mut stream = client.get_stream(25);
 

--- a/server/src/ingestion.rs
+++ b/server/src/ingestion.rs
@@ -22,10 +22,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use futures::{executor::block_on, stream::StreamExt};
+use paho_mqtt as mqtt;
+use std::{process, time::Duration};
+use paho_mqtt::AsyncClient;
 
 pub struct Ingestor {
     broker: String,
     client: String,
     topics: [String],
     qos: [u8; 2],
+}
+
+impl Ingestor {
+    /// Create a broker client with the specified Ingestor fields.
+    pub fn create_client(self) -> AsyncClient {
+        let create_options = mqtt::CreateOptionsBuilder::new()
+            .server_uri(self.broker)
+            .client_id(self.client)
+            .finalize();
+
+        let mut client = mqtt::AsyncClient::new(create_options).unwrap_or_else(|e| {
+            println!("Error creating the client: {:?}", e);
+            process::exit(1);
+        });
+
+        client
+    }
 }

--- a/server/src/ingestion.rs
+++ b/server/src/ingestion.rs
@@ -28,10 +28,10 @@ use paho_mqtt::{AsyncClient, AsyncReceiver, Message};
 use std::{process, time::Duration};
 
 pub struct Ingestor {
-    broker: &'static str,
-    client_id: &'static str,
-    topics: &'static [&'static str],
-    qos: &'static [i32],
+    pub broker: &'static str,
+    pub client_id: &'static str,
+    pub topics: &'static [&'static str],
+    pub qos: &'static [i32],
 }
 
 // TODO: Add debug logging with tracer log.
@@ -42,7 +42,7 @@ impl Ingestor {
     /// * `compress_callback` - Function called on the messages when a batch of messages has been
     /// ingested into memory. Due to possible memory limitations, the messages can also be supplied
     /// to the compress callback through a file path.
-    fn start(self, compress_callback: fn()) {
+    pub fn start(self, compress_callback: fn(msg: Message)) {
         let mut client = create_client(self.broker, self.client_id);
 
         if let Err(err) = block_on(async {
@@ -100,7 +100,7 @@ async fn subscribe_to_broker(
 async fn ingest_messages(
     stream: &mut AsyncReceiver<Option<Message>>,
     client: &mut AsyncClient,
-    compress_callback: fn(),
+    compress_callback: fn(msg: Message),
 ) {
     // While the message stream resolves to the next item in the stream, ingest the messages.
     while let Some(msg_opt) = stream.next().await {

--- a/server/src/ingestion.rs
+++ b/server/src/ingestion.rs
@@ -24,5 +24,8 @@
  */
 
 pub struct Ingestor {
-
+    broker: String,
+    client: String,
+    topics: [String],
+    qos: [u8; 2],
 }

--- a/server/src/ingestion.rs
+++ b/server/src/ingestion.rs
@@ -41,12 +41,21 @@ pub struct Ingestor {
 
 impl Ingestor {
     /// Create a new ingestor. Note that `topics` and `qos` must be of the same length.
-    pub fn new(broker: String, client_id: String, topics: Vec<String>, qos: Vec<i32>) -> Self {
-        Self {
-            broker,
-            client_id,
-            topics,
-            qos,
+    pub fn try_new(
+        broker: String,
+        client_id: String,
+        topics: Vec<String>,
+        qos: Vec<i32>,
+    ) -> Result<Self, String> {
+        if topics.len() != qos.len() {
+            Err("The number of topics must be the same as the number of QoS specifiers.".to_string())
+        } else {
+            Ok(Self {
+                broker,
+                client_id,
+                topics,
+                qos,
+            })
         }
     }
 
@@ -118,5 +127,34 @@ impl Ingestor {
                 storage_engine.insert_message(msg);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_can_create_ingestor() {
+        let ingestor = Ingestor::try_new(
+            "broker".to_string(),
+            "client".to_string(),
+            vec!["topic_1".to_string(), "topic_2".to_string()],
+            vec![1, 1],
+        );
+
+        assert!(ingestor.is_ok())
+    }
+
+    #[test]
+    fn test_topics_and_qos_cannot_be_different_length() {
+        let ingestor = Ingestor::try_new(
+            "broker".to_string(),
+            "client".to_string(),
+            vec!["topic_1".to_string(), "topic_2".to_string()],
+            vec![1, 1, 1],
+        );
+
+        assert!(ingestor.is_err())
     }
 }

--- a/server/src/ingestion.rs
+++ b/server/src/ingestion.rs
@@ -1,14 +1,4 @@
-//! Module containing support for data ingestion from an MQTT broker.
-//!
-//! The connection settings of the ingestor are controlled through the broker, client_id, topics,
-//! and qos fields. Note that the client ID should be unique.
-//!
-//! To use the ingestor, run the "ingestor.start()" function. This functions first creates the client.
-//! Then it uses the created client to connect to the broker and subscribe to the specified topics.
-//! The connection message stream is then looped over to ingest the messages that are published to the topics.
-//!
-
-/* Copyright 2021 The MiniModelarDB Contributors
+/* Copyright 2022 The MiniModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,15 +12,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+//! Support for data ingestion from an MQTT broker.
+//!
+//! To use the ingestor, run the "ingestor.start()" function. This function first creates the client.
+//! Then it uses the created client to connect to the broker and subscribe to the specified topics.
+//! The connection message stream is then looped over to ingest the messages that are published to the topics.
+
 use futures::{executor::block_on, stream::StreamExt};
 use paho_mqtt as mqtt;
 use paho_mqtt::{AsyncClient, AsyncReceiver, Message};
 use std::{process, time::Duration};
 
+/// A single MQTT client that can subscribe to the specified broker and ingest messages from the
+/// specified topics. Note that after creation, the ingestor needs to be started to ingest messages.
 pub struct Ingestor {
+    /// Server URI for the MQTT broker.
     pub broker: &'static str,
+    /// ID that is used to uniquely identify the ingestor as a client to the MQTT broker.
     pub client_id: &'static str,
+    /// Specific topics that should be subscribed to. Use "\[*]" to subscribe to all topics.
     pub topics: &'static [&'static str],
+    /// The quality of service for each subscribed-to topic. Should be of same length as `topics` field.
     pub qos: &'static [i32],
 }
 
@@ -53,7 +56,6 @@ impl Ingestor {
     }
 }
 
-/** Private Functions **/
 /// Create a broker client with the given broker URI and client ID.
 fn create_client(broker: &str, client_id: &str) -> AsyncClient {
     let create_options = mqtt::CreateOptionsBuilder::new()

--- a/server/src/ingestion.rs
+++ b/server/src/ingestion.rs
@@ -95,13 +95,15 @@ impl Ingestor {
         &self,
         client: &mut AsyncClient,
     ) -> AsyncReceiver<Option<Message>> {
-        // Get the message stream before connecting since messages can arrive as soon as the connection is made.
+        // Get the message stream before connecting since messages can arrive as soon as the connection
+        // is made. A buffer size of 25 is used since it is the standard in paho_mqtt examples.
         let mut stream = client.get_stream(25);
 
         // Define the last will and testament message to notify other clients about disconnect.
         let lwt = mqtt::Message::new("mdb_lwt", "ModelarDB lost connection", mqtt::QOS_1);
 
         let connect_options = mqtt::ConnectOptionsBuilder::new()
+            // An interval of 30 seconds is used since it is the standard in paho_mqtt examples.
             .keep_alive_interval(Duration::from_secs(30))
             .mqtt_version(mqtt::MQTT_VERSION_3_1_1)
             .clean_session(false)

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -21,6 +21,7 @@ mod remote;
 mod storage;
 mod tables;
 mod types;
+mod ingestion;
 
 use std::sync::Arc;
 


### PR DESCRIPTION
This PR includes an Ingestor component that can connect to an MQTT broker, subscribe to specific topics and insert messages from these topics into the storage engine. It should be noted that this PR does not include unit tests since testing the ingestor requires an MQTT broker and simulator. This component should instead be tested as part of integration testing.