### PR TITLE
Remove constant sensor count requirement.

### DIFF
--- a/server/src/storage/data_point.rs
+++ b/server/src/storage/data_point.rs
@@ -16,11 +16,12 @@
 //! A single data point. Note that this struct is mainly used when converting from a raw MQTT
 //! message to Apache Arrow.
 
+use std::fmt;
+use std::fmt::Formatter;
 use paho_mqtt::Message;
 
 use crate::types::{Timestamp, Value};
 
-#[derive(Debug)]
 pub struct DataPoint {
     pub timestamp: Timestamp,
     pub value: Value,
@@ -67,6 +68,12 @@ impl DataPoint {
     /// Generate a unique key for a time series based on the information in the message.
     pub fn generate_unique_key(&self) -> String {
         self.metadata.join("-")
+    }
+}
+
+impl fmt::Display for DataPoint {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "(Timestamp: {}, Value: {})", self.timestamp, self.value)
     }
 }
 

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -165,14 +165,13 @@ impl StorageEngine {
 
         // Iterate through the finished segments to find a segment that is in memory.
         for finished in self.compression_queue.iter_mut() {
-            if finished.uncompressed_segment.get_memory_size() > 0 {
-                info!("Spilling the segment with key '{}' to a Parquet file.", finished.key);
+            info!("Spilling the segment with key '{}' to a Parquet file.", finished.key);
 
-                finished.spill_segment();
-
+            if let Ok(path) = finished.spill_to_parquet() {
                 // Add the size of the segment back to the remaining reserved bytes.
                 self.remaining_bytes += SegmentBuilder::get_memory_size();
 
+                info!("Spilled the segment to '{}'. Remaining bytes: {}.", path, self.remaining_bytes);
                 return ();
             }
         }

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -170,7 +170,9 @@ impl StorageEngine {
                 return ();
             }
         }
-        // TODO: If not able to find any in-memory finished segments, we should panic.
+
+        // If not able to find any in-memory finished segments, we should panic.
+        panic!("Not enough reserved memory to hold all necessary segment builders.")
     }
 }
 

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -123,7 +123,7 @@ impl StorageEngine {
         write_batch_to_parquet(batch, path);
     }
 
-    /// Move `segment_builder` to the the compression queue.
+    /// Move `segment_builder` to the compression queue.
     fn enqueue_segment(&mut self, key: String, segment_builder: SegmentBuilder) {
         let finished_segment = FinishedSegment {
             key,

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -39,13 +39,7 @@ use crate::types::Timestamp;
 // Note that the initial capacity has to be a multiple of 64 bytes to avoid the actual capacity
 // being larger due to internal alignment when allocating memory for the builders.
 const INITIAL_BUILDER_CAPACITY: usize = 64;
-// TODO: The sensor count should be dynamic and not predefined.
-const SENSOR_COUNT: usize = 2;
 const RESERVED_BYTES: usize = 5000;
-
-// TODO: Maybe remove finished segment and add get_key to uncompressed segment.
-// TODO: Remove the sensor count constant.
-// TODO: Set the initial remaining bytes to be equal to reserved bytes.
 
 // TODO: Before creating a new builder, check if there is enough space for the builder.
 // TODO: If there is, create it and remove the builder size from the remaining bytes.
@@ -66,6 +60,7 @@ const RESERVED_BYTES: usize = 5000;
 // TODO: Add test for checking that we cannot buffer a buffered finished segment.
 // TODO: Add test for checking that we can buffer a unbuffered finished segment.
 
+// TODO: Maybe remove finished segment and add get_key to uncompressed segment.
 // TODO: Maybe split insert message into separate functions to avoid one large function.
 
 /// Manages all uncompressed data, both while being built and when finished.
@@ -84,7 +79,7 @@ impl StorageEngine {
             // TODO: Maybe create with estimated capacity to avoid reallocation.
             data: HashMap::new(),
             compression_queue: VecDeque::new(),
-            remaining_bytes: RESERVED_BYTES - (SegmentBuilder::get_memory_size() * SENSOR_COUNT)
+            remaining_bytes: RESERVED_BYTES
         }
     }
 

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -41,15 +41,6 @@ use crate::types::Timestamp;
 const INITIAL_BUILDER_CAPACITY: usize = 64;
 const RESERVED_BYTES: usize = 5000;
 
-// TODO: Before creating a new builder, check if there is enough space for the builder.
-// TODO: If there is, create it and remove the builder size from the remaining bytes.
-// TODO: If there is not, we assume that it is because there is finished uncompressed segments in the queue.
-
-// TODO: We should find the first uncompressed, unbuffered finished segment in the queue and buffer it.
-// TODO: This could be done with a function on the UncompressedSegment trait.
-// TODO: It should return Ok if a unbuffered segment was buffered and Err if trying to buffer an already buffered segment.
-// TODO: If not able to find any unbuffered finished segments, we should panic.
-
 // TODO: When queueing a finished segment, add the builder size to the remaining bytes.
 
 // TODO: Add test for decrementing the remaining bytes when creating a builder.
@@ -105,7 +96,14 @@ impl StorageEngine {
                 } else {
                     info!("Could not find segment with key '{}'. Creating segment.", key);
 
+                    // If there is not enough space for a new segment, spill a finished segment.
+                    if SegmentBuilder::get_memory_size() > self.remaining_bytes {
+                        // TODO: Spill segment.
+                    }
+
+                    // Create a new segment and remove the size from the reserved remaining memory.
                     let mut segment = SegmentBuilder::new();
+                    self.remaining_bytes -= SegmentBuilder::get_memory_size();
                     segment.insert_data(&data_point);
 
                     self.data.insert(key, segment);
@@ -160,6 +158,14 @@ impl StorageEngine {
 
         let finished_segment = FinishedSegment { key, uncompressed_segment };
         self.compression_queue.push_back(finished_segment);
+    }
+
+    /// Spill the first in-memory finished segment in the compression queue.
+    fn spill_finished_segment() {
+        // TODO: We should find the first uncompressed, unbuffered finished segment in the queue and buffer it.
+        // TODO: This could be done with a function on the UncompressedSegment trait.
+        // TODO: It should return Ok if a unbuffered segment was buffered and Err if trying to buffer an already buffered segment.
+        // TODO: If not able to find any unbuffered finished segments, we should panic.
     }
 }
 

--- a/server/src/storage/segment.rs
+++ b/server/src/storage/segment.rs
@@ -94,16 +94,13 @@ impl SegmentBuilder {
         self.timestamps.append_value(data_point.timestamp);
         self.values.append_value(data_point.value);
 
-        info!("Inserted data point into {}.", self)
+        info!("Inserted data point into segment with {}.", self)
     }
 }
 
 impl fmt::Display for SegmentBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.write_str(&format!("Segment with {} data point(s) ", self.get_length()));
-        f.write_str(&format!("(Capacity: {})", self.get_capacity()));
-
-        Ok(())
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{} data point(s) (Capacity: {})", self.get_length(), self.get_capacity())
     }
 }
 

--- a/server/src/storage/segment.rs
+++ b/server/src/storage/segment.rs
@@ -42,6 +42,8 @@ pub trait UncompressedSegment {
     fn get_record_batch(&mut self) -> RecordBatch;
 
     fn get_memory_size(&self) -> usize;
+
+    fn spill_segment(&mut self) -> Result<(), String>;
 }
 
 /// A single segment being built, consisting of an ordered sequence of timestamps and values. Note
@@ -124,6 +126,12 @@ impl UncompressedSegment for SegmentBuilder {
     fn get_memory_size(&self) -> usize {
         SegmentBuilder::get_memory_size()
     }
+
+    /// Spill the in-memory segment to a Parquet file and return Ok when finished.
+    fn spill_segment(&mut self) -> Result<(), String> {
+        // TODO Spill segment.
+        Ok(())
+    }
 }
 
 /// A single segment that has been spilled to a Parquet file due to memory constraints.
@@ -172,6 +180,11 @@ impl UncompressedSegment for SpilledSegment {
     /// Return 0 since the data is not kept in memory.
     fn get_memory_size(&self) -> usize {
         0
+    }
+
+    /// Since the segment has already been spilled, return Err.
+    fn spill_segment(&mut self) -> Result<(), String> {
+        Err(format!("The segment has already been spilled to '{}'.", self.path))
     }
 }
 

--- a/server/src/storage/segment.rs
+++ b/server/src/storage/segment.rs
@@ -173,23 +173,7 @@ impl UncompressedSegment for SpilledSegment {
     fn get_memory_size(&self) -> usize {
         0
     }
-}
 
-/// Representing either an in-memory or spilled segment that is finished and ready for compression.
-pub struct FinishedSegment {
-    pub key: String,
-    pub uncompressed_segment: Box<dyn UncompressedSegment>,
-}
-
-impl FinishedSegment {
-    /// If in memory, spill the segment to Parquet and return Ok, otherwise return Err.
-    pub fn spill_segment(&mut self) -> Result<(), String> {
-        if self.uncompressed_segment.get_memory_size() > 0 {
-            // TODO: Spill segment.
-            Ok(())
-        } else {
-            Err(format!("The segment has already been spilled to '{}'.", self.path))
-        }
     }
 }
 

--- a/server/src/storage/segment.rs
+++ b/server/src/storage/segment.rs
@@ -174,7 +174,7 @@ impl UncompressedSegment for SpilledSegment {
         record_batch_reader.next().unwrap().unwrap()
     }
 
-    /// Return 0 since the data is not kept in memory.
+    /// Since the data is not kept in memory, return 0.
     fn get_memory_size(&self) -> usize {
         0
     }

--- a/server/src/storage/segment.rs
+++ b/server/src/storage/segment.rs
@@ -28,6 +28,7 @@ use datafusion::arrow::datatypes::{ArrowPrimitiveType, Field, Schema};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::parquet::arrow::{ArrowReader, ParquetFileArrowReader, ProjectionMask};
 use datafusion::parquet::file::reader::{FileReader, SerializedFileReader};
+use tracing::info;
 
 use crate::storage::data_point::DataPoint;
 use crate::storage::{write_batch_to_parquet, INITIAL_BUILDER_CAPACITY};
@@ -89,7 +90,7 @@ impl SegmentBuilder {
         self.timestamps.append_value(data_point.timestamp);
         self.values.append_value(data_point.value);
 
-        println!("Inserted data point into {}.", self)
+        info!("Inserted data point into {}.", self)
     }
 }
 

--- a/server/src/storage/segment.rs
+++ b/server/src/storage/segment.rs
@@ -282,4 +282,13 @@ mod tests {
 
         assert_eq!(spilled_segment.get_memory_size(), 0)
     }
+
+    #[test]
+    fn test_cannot_spill_already_spilled_segment() {
+        let mut spilled_segment = SpilledSegment {
+            path: "path".to_string(),
+        };
+
+        assert!(spilled_segment.spill_to_parquet("key".to_string()).is_err())
+    }
 }

--- a/server/src/storage/segment.rs
+++ b/server/src/storage/segment.rs
@@ -194,11 +194,13 @@ pub struct FinishedSegment {
 }
 
 impl FinishedSegment {
-    /// If in memory, spill the segment to Parquet and return Ok, otherwise return Err.
-    pub fn spill_segment(&mut self) {
-        if self.uncompressed_segment.get_memory_size() > 0 {
-            // TODO: Spill segment.
-        }
+    /// If in memory, spill the segment to Parquet and return the path, otherwise return Err.
+    pub fn spill_to_parquet(&mut self) -> Result<String, String> {
+        let spilled_segment = self.uncompressed_segment.spill_to_parquet()?;
+        let path = spilled_segment.path.clone();
+        self.uncompressed_segment = Box::new(spilled_segment);
+
+        Ok(path)
     }
 }
 

--- a/server/src/storage/segment.rs
+++ b/server/src/storage/segment.rs
@@ -15,8 +15,7 @@
 
 //! Support for different kinds of uncompressed segments. The SegmentBuilder struct provides support
 //! for inserting and storing data in an in-memory segment. SpilledSegment provides support for
-//! storing uncompressed data in a Parquet files. FinishedSegment provides a generalized interface
-//! for using the segments outside the storage engine.
+//! storing uncompressed data in a Parquet files.
 
 use std::fmt::Formatter;
 use std::fs::File;
@@ -165,10 +164,7 @@ impl SpilledSegment {
 
         write_batch_to_parquet(data, path.clone());
 
-        Self {
-            path,
-            key
-        }
+        Self { path, key }
     }
 }
 
@@ -271,6 +267,14 @@ mod tests {
         assert_eq!(data.num_rows(), 2);
     }
 
+    #[test]
+    fn get_segment_builder_key() {
+        let data_point = get_data_point();
+        let mut segment_builder = SegmentBuilder::new(data_point.generate_unique_key());
+
+        assert_eq!(segment_builder.get_key(), "ModelarDB-test")
+    }
+
     fn get_data_point() -> DataPoint {
         let message = Message::new("ModelarDB/test", "[1657878396943245, 30]", 1);
         DataPoint::from_message(&message).unwrap()
@@ -279,11 +283,22 @@ mod tests {
     // Tests for SpilledSegment.
     #[test]
     fn test_get_spilled_segment_memory_size() {
-        let spilled_segment = SpilledSegment {
-            path: "".to_string(),
-            key: "".to_string()
-        };
+        let spilled_segment = get_empty_spilled_segment();
 
         assert_eq!(spilled_segment.get_memory_size(), 0)
+    }
+
+    #[test]
+    fn test_get_spilled_segment_key() {
+        let spilled_segment = get_empty_spilled_segment();
+
+        assert_eq!(spilled_segment.get_key(), "key")
+    }
+
+    fn get_empty_spilled_segment() -> SpilledSegment {
+        SpilledSegment {
+            path: "path".to_string(),
+            key: "key".to_string()
+        }
     }
 }

--- a/server/src/storage/segment.rs
+++ b/server/src/storage/segment.rs
@@ -181,6 +181,18 @@ pub struct FinishedSegment {
     pub uncompressed_segment: Box<dyn UncompressedSegment>,
 }
 
+impl FinishedSegment {
+    /// If in memory, spill the segment to Parquet and return Ok, otherwise return Err.
+    pub fn spill_segment(&mut self) -> Result<(), String> {
+        if self.uncompressed_segment.get_memory_size() > 0 {
+            // TODO: Spill segment.
+            Ok(())
+        } else {
+            Err(format!("The segment has already been spilled to '{}'.", self.path))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/server/src/storage/segment.rs
+++ b/server/src/storage/segment.rs
@@ -194,7 +194,9 @@ pub struct FinishedSegment {
 impl FinishedSegment {
     /// If in memory, spill the segment to Parquet and return the path, otherwise return Err.
     pub fn spill_to_parquet(&mut self) -> Result<String, String> {
-        let spilled = self.uncompressed_segment.spill_to_parquet(self.key.clone())?;
+        let spilled = self
+            .uncompressed_segment
+            .spill_to_parquet(self.key.clone())?;
 
         let path = spilled.path.clone();
         self.uncompressed_segment = Box::new(spilled);

--- a/server/src/storage/segment.rs
+++ b/server/src/storage/segment.rs
@@ -42,8 +42,6 @@ pub trait UncompressedSegment {
     fn get_record_batch(&mut self) -> RecordBatch;
 
     fn get_memory_size(&self) -> usize;
-
-    fn spill_segment(&mut self) -> Result<(), String>;
 }
 
 /// A single segment being built, consisting of an ordered sequence of timestamps and values. Note
@@ -126,12 +124,6 @@ impl UncompressedSegment for SegmentBuilder {
     fn get_memory_size(&self) -> usize {
         SegmentBuilder::get_memory_size()
     }
-
-    /// Spill the in-memory segment to a Parquet file and return Ok when finished.
-    fn spill_segment(&mut self) -> Result<(), String> {
-        // TODO Spill segment.
-        Ok(())
-    }
 }
 
 /// A single segment that has been spilled to a Parquet file due to memory constraints.
@@ -180,11 +172,6 @@ impl UncompressedSegment for SpilledSegment {
     /// Return 0 since the data is not kept in memory.
     fn get_memory_size(&self) -> usize {
         0
-    }
-
-    /// Since the segment has already been spilled, return Err.
-    fn spill_segment(&mut self) -> Result<(), String> {
-        Err(format!("The segment has already been spilled to '{}'.", self.path))
     }
 }
 


### PR DESCRIPTION
The previous version of the storage engine had the requirement that the amount of sensors outputting data into the system had to be constant and known before starting. This requirement has been removed so it is now possible to add and remove sensors while the system is running.