### PR TITLE
Saving compressed segments together. 

### DIFF
--- a/server/src/storage/data_point.rs
+++ b/server/src/storage/data_point.rs
@@ -35,29 +35,29 @@ impl DataPoint {
         let payload = message.payload_str();
 
         if payload.is_empty() {
-            Err("The message is empty.".to_string())
+            Err("The message is empty.".to_owned())
         } else {
             if payload.chars().next().unwrap() != '[' || payload.chars().last().unwrap() != ']' {
-                Err("The message does not have the correct format.".to_string())
+                Err("The message does not have the correct format.".to_owned())
             } else {
                 let first_last_off: &str = &payload[1..payload.len() - 1];
                 let timestamp_value: Vec<&str> = first_last_off.split(", ").collect();
 
                 if timestamp_value.len() != 2 {
-                    Err("The message can only contain a timestamp and a single value.".to_string())
+                    Err("The message can only contain a timestamp and a single value.".to_owned())
                 } else {
                     if let Ok(timestamp) = timestamp_value[0].parse::<Timestamp>() {
                         if let Ok(value) = timestamp_value[1].parse::<Value>() {
                             Ok(Self {
                                 timestamp,
                                 value,
-                                metadata: vec![message.topic().to_string().replace("/", "-")],
+                                metadata: vec![message.topic().to_owned().replace("/", "-")],
                             })
                         } else {
-                            Err("Value could not be parsed.".to_string())
+                            Err("Value could not be parsed.".to_owned())
                         }
                     } else {
-                        Err("Timestamp could not be parsed.".to_string())
+                        Err("Timestamp could not be parsed.".to_owned())
                     }
                 }
             }
@@ -91,7 +91,7 @@ mod tests {
         let data_point = result.unwrap();
         assert_eq!(data_point.timestamp, 1657878396943245);
         assert_eq!(data_point.value, 30 as f32);
-        assert_eq!(data_point.metadata, vec!["ModelarDB-test".to_string()])
+        assert_eq!(data_point.metadata, vec!["ModelarDB-test".to_owned()])
     }
 
     #[test]

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -38,19 +38,6 @@ use crate::storage::segment::{FinishedSegment, SegmentBuilder};
 use crate::storage::time_series::CompressedTimeSeries;
 use crate::types::Timestamp;
 
-// TODO: When the "save_compressed_data" method on the SE is called it should check if there already is a compressed time series.
-// TODO: If there is, append to the compressed time series.
-// TODO: If there is not, create a new and add it to the compressed data queue.
-
-// TODO: Since the size of compressed segments is not constant we need to have a private function in the struct to calculate the size in bytes.
-// TODO: This size should be returned to the storage engine so the remaining bytes can be updated. Maybe do this before saving.
-// TODO: If there is not enough space for the compressed segment. Pop the first first compressed time series and add the size back.
-// TODO: Since the incoming segment can be very large we might need to save multiple time series to disk.
-// TODO: If there is none left in the queue, we have to save the given compressed segment directly (maybe just create compressed time series and save immediately).
-// TODO: If there is eventually enough space save the compressed segment in a compressed time series after.
-
-// TODO: If a compressed time series reaches this size it should be saved to a file instead of appended to further.
-
 // TODO: Look into moving handling of uncompressed and compressed data into separate structs.
 
 // Note that the initial capacity has to be a multiple of 64 bytes to avoid the actual capacity
@@ -144,13 +131,18 @@ impl StorageEngine {
         }
     }
 
-    /// Write `batch` to a persistent Apache Parquet file on disk.
-    pub fn save_compressed_data(key: String, first_timestamp: Timestamp, batch: RecordBatch) {
-        let folder_path = format!("storage/{}/compressed", key);
-        fs::create_dir_all(&folder_path);
+    // TODO: Add log messages to this function. Maybe use a span.
+    /// Insert `batch` into the in-memory compressed time series buffer.
+    pub fn insert_compressed_data(key: Strin, batch: RecordBatch) {
+        // TODO: Check if there already is a compressed time series with that key.
+        // TODO: If there is, append to the compressed time series.
+        // TODO: If there is not, create a new and add it to the compressed data queue.
+        // TODO: Appending should return the size of the compressed segment.
 
-        let path = format!("{}/{}.parquet", folder_path, first_timestamp);
-        write_batch_to_parquet(batch, path);
+        // TODO: If there is not enough space for the compressed segment. Pop the first first compressed time series and add the size back.
+        // TODO: Since the incoming segment can be very large we might need to save multiple time series to disk.
+        // TODO: If there is none left in the queue, we have to save the given compressed segment directly (maybe just create compressed time series and save immediately).
+        // TODO: Update the remaining bytes.
     }
 
     /// Move `segment_builder` to the compression queue.
@@ -200,6 +192,14 @@ fn write_batch_to_parquet(batch: RecordBatch, path: String) {
     writer.write(&batch).expect("Writing batch.");
     writer.close().unwrap();
 }
+
+// TODO: Add a test for inserting a compressed segment into a new compressed time series.
+// TODO: Add a test for inserting a compressed segment into an existing compressed time series.
+// TODO: Add a test for updating the remaining bytes when inserting.
+// TODO: Add a test for updating the remaining bytes when saving a compressed time series to disk (I/O).
+// TODO: Add a test for saving the first compressed time series when out of memory (I/O).
+// TODO: Add a test for saving multiple when out of memory if incoming batch is large enough (I/O).
+// TODO: Add a test for saving directly if there is no compressed time series in the queue to save (I/O).
 
 #[cfg(test)]
 mod tests {

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -347,11 +347,6 @@ mod tests {
             .generate_unique_key()
     }
 
-    // TODO: Add a test for updating the remaining bytes when saving a compressed time series to disk (I/O).
-    // TODO: Add a test for saving the first compressed time series when out of memory (I/O).
-    // TODO: Add a test for saving multiple when out of memory if incoming batch is large enough (I/O).
-    // TODO: Add a test for saving compressed time series when the max size is reached (I/O).
-
     // Tests for compressed data.
     #[test]
     fn test_cannot_insert_valid_compressed_segment() {

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -30,7 +30,7 @@ use datafusion::parquet::arrow::ArrowWriter;
 use datafusion::parquet::basic::Encoding;
 use datafusion::parquet::file::properties::WriterProperties;
 use paho_mqtt::Message;
-use tracing::{error, info, info_span};
+use tracing::{info, info_span};
 
 use crate::storage::data_point::DataPoint;
 use crate::storage::segment::{FinishedSegment, SegmentBuilder};
@@ -136,19 +136,19 @@ impl StorageEngine {
         let _span = info_span!("insert_compressed_segment", key = key.clone()).entered();
         info!("Inserting batch with {} rows into compressed time series.", batch.num_rows());
 
-        let mut compressed_segment_size;
+        let compressed_segment_size;
 
         // Since the compressed segment is already in memory, insert the segment in to the structure
         // first and check if the reserved memory limit is exceeded after.
         if let Some(time_series) = self.compressed_data.get_mut(&key) {
             info!("Found existing compressed time series.");
 
-            compressed_segment_size = time_series.append_segment(batch).unwrap();
+            compressed_segment_size = time_series.append_segment(batch);
         } else {
             info!("Could not find compressed time series. Creating compressed time series.");
 
             let mut time_series = CompressedTimeSeries::new();
-            compressed_segment_size = time_series.append_segment(batch).unwrap();
+            compressed_segment_size = time_series.append_segment(batch);
 
             self.compressed_data.insert(key.clone(), time_series);
             self.compression_queue.push_back(key.clone());

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -49,8 +49,7 @@ use crate::types::Timestamp;
 // TODO: If there is none left in the queue, we have to save the given compressed segment directly (maybe just create compressed time series and save immediately).
 // TODO: If there is eventually enough space save the compressed segment in a compressed time series after.
 
-// TODO: Switch folder structure to key/uncompressed – key/compressed.
-// TODO: Add a max compressed file size constant. If a compressed time series reaches this size it should be saved to a file instead of appended to further.
+// TODO: If a compressed time series reaches this size it should be saved to a file instead of appended to further.
 
 // TODO: Look into moving handling of uncompressed and compressed data into separate structs.
 
@@ -147,7 +146,7 @@ impl StorageEngine {
 
     /// Write `batch` to a persistent Apache Parquet file on disk.
     pub fn save_compressed_data(key: String, first_timestamp: Timestamp, batch: RecordBatch) {
-        let folder_path = format!("compressed/{}", key);
+        let folder_path = format!("storage/{}/compressed", key);
         fs::create_dir_all(&folder_path);
 
         let path = format!("{}/{}.parquet", folder_path, first_timestamp);

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -184,7 +184,7 @@ impl StorageEngine {
 
         // Iterate through the finished segments to find a segment that is in memory.
         for finished in self.finished_queue.iter_mut() {
-            if let Ok(path) = finished.spill_to_parquet() {
+            if let Ok(path) = finished.spill_to_apache_parquet() {
                 // Add the size of the segment back to the remaining reserved bytes.
                 self.uncompressed_remaining_memory_in_bytes += SegmentBuilder::get_memory_size();
 
@@ -211,7 +211,7 @@ impl StorageEngine {
 
             let mut time_series = self.compressed_data.remove(&key).unwrap();
             let time_series_size = time_series.size_in_bytes.clone();
-            time_series.save_to_parquet(key.clone());
+            time_series.save_to_apache_parquet(key.clone());
 
             self.compressed_remaining_memory_in_bytes += time_series_size as isize;
 
@@ -225,7 +225,7 @@ impl StorageEngine {
 
 // TODO: Test using more efficient encoding. Plain encoding makes it easier to read the files externally.
 /// Write `batch` to an Apache Parquet file at the location given by `path`.
-fn write_batch_to_parquet(batch: RecordBatch, path: String) {
+fn write_batch_to_apache_parquet(batch: RecordBatch, path: String) {
     let file = File::create(path).unwrap();
     let props = WriterProperties::builder()
         .set_dictionary_enabled(false)

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -19,6 +19,7 @@
 
 mod data_point;
 mod segment;
+mod time_series;
 
 use std::collections::vec_deque::VecDeque;
 use std::collections::HashMap;
@@ -34,21 +35,8 @@ use tracing::{error, info, info_span};
 
 use crate::storage::data_point::DataPoint;
 use crate::storage::segment::{FinishedSegment, SegmentBuilder};
+use crate::storage::time_series::CompressedTimeSeries;
 use crate::types::Timestamp;
-
-// TODO: Add new constant that defines how much memory is used for compressed vs. uncompressed (maybe make this dynamic?).
-// TODO: Add a new field to the StorageEngine that can hold compressed data.
-// TODO: Rename the current data field to "uncompressed_data".
-
-// TODO: To ensure that data is saved in the correct order we should have a queue for the compressed data.
-// TODO: It should be a queue of CompressedTimeSeries structs.
-
-// TODO: The struct should have a compressed_segments field with a list of segments that is appended to.
-// TODO: To make it easier to save maybe also save the path when first creating it (key and first timestamp).
-// TODO: To make it possible to update the remaining bytes when saving to a file it should have the continuously updated total size.
-
-// TODO: It should have a method to append to this field that checks the given batch to ensure it has the correct schema.
-// TODO: It should have a method that can save the compressed segments to a single file.
 
 // TODO: When the "save_compressed_data" method on the SE is called it should check if there already is a compressed time series.
 // TODO: If there is, append to the compressed time series.
@@ -61,35 +49,44 @@ use crate::types::Timestamp;
 // TODO: If there is none left in the queue, we have to save the given compressed segment directly (maybe just create compressed time series and save immediately).
 // TODO: If there is eventually enough space save the compressed segment in a compressed time series after.
 
-// TODO: Look into using prioritized queue.
-// TODO: To ensure we can do lookup with the key, we need a hashmap, maybe a prioritized hashmap??
-// TODO: Maybe use both a hashmap for storage and a queue for choosing which time series should be saved.
-
 // TODO: Switch folder structure to key/uncompressed – key/compressed.
 // TODO: Add a max compressed file size constant. If a compressed time series reaches this size it should be saved to a file instead of appended to further.
+
+// TODO: Look into moving handling of uncompressed and compressed data into separate structs.
 
 // Note that the initial capacity has to be a multiple of 64 bytes to avoid the actual capacity
 // being larger due to internal alignment when allocating memory for the builders.
 const INITIAL_BUILDER_CAPACITY: usize = 64;
-const RESERVED_MEMORY_IN_BYTES: usize = 5000;
+const UNCOMPRESSED_RESERVED_MEMORY_IN_BYTES: usize = 5000;
+const COMPRESSED_RESERVED_MEMORY_IN_BYTES: usize = 5000;
+const MAX_COMPRESSED_FILE_SIZE_IN_BYTES: usize = 10240;
 
 /// Manages all uncompressed data, both while being built and when finished.
 pub struct StorageEngine {
     /// The uncompressed segments while they are being built.
-    data: HashMap<String, SegmentBuilder>,
+    uncompressed_data: HashMap<String, SegmentBuilder>,
     /// Prioritized queue of finished segments that are ready for compression.
-    compression_queue: VecDeque<FinishedSegment>,
+    finished_queue: VecDeque<FinishedSegment>,
+    /// The compressed segments before they are saved to persistent storage.
+    compressed_data: HashMap<String, CompressedTimeSeries>,
+    /// Prioritized queue of time series keys that can be saved to persistent storage.
+    compression_queue: VecDeque<String>,
     /// How many bytes of memory that are left for storing uncompressed segments.
-    remaining_memory_in_bytes: usize,
+    uncompressed_remaining_memory_in_bytes: usize,
+    /// How many bytes of memory that are left for storing compressed segments.
+    compressed_remaining_memory_in_bytes: usize,
 }
 
 impl StorageEngine {
     pub fn new() -> Self {
         Self {
             // TODO: Maybe create with estimated capacity to avoid reallocation.
-            data: HashMap::new(),
+            uncompressed_data: HashMap::new(),
+            finished_queue: VecDeque::new(),
+            compressed_data: HashMap::new(),
             compression_queue: VecDeque::new(),
-            remaining_memory_in_bytes: RESERVED_MEMORY_IN_BYTES,
+            uncompressed_remaining_memory_in_bytes: UNCOMPRESSED_RESERVED_MEMORY_IN_BYTES,
+            compressed_remaining_memory_in_bytes: COMPRESSED_RESERVED_MEMORY_IN_BYTES,
         }
     }
 
@@ -102,7 +99,7 @@ impl StorageEngine {
 
                 info!("Inserting data point '{}' into segment.", data_point);
 
-                if let Some(segment) = self.data.get_mut(&key) {
+                if let Some(segment) = self.uncompressed_data.get_mut(&key) {
                     info!("Found existing segment.");
 
                     segment.insert_data(&data_point);
@@ -110,24 +107,24 @@ impl StorageEngine {
                     if segment.is_full() {
                         info!("Segment is full, moving it to the compression queue.");
 
-                        let full_segment = self.data.remove(&key).unwrap();
+                        let full_segment = self.uncompressed_data.remove(&key).unwrap();
                         self.enqueue_segment(key, full_segment)
                     }
                 } else {
                     info!("Could not find segment. Creating segment.");
 
                     // If there is not enough memory for a new segment, spill a finished segment.
-                    if SegmentBuilder::get_memory_size() > self.remaining_memory_in_bytes {
+                    if SegmentBuilder::get_memory_size() > self.uncompressed_remaining_memory_in_bytes {
                         self.spill_finished_segment();
                     }
 
                     // Create a new segment and reduce the remaining amount of reserved memory by its size.
                     let mut segment = SegmentBuilder::new();
-                    self.remaining_memory_in_bytes -= SegmentBuilder::get_memory_size();
-                    info!("Created segment. Remaining bytes: {}.", self.remaining_memory_in_bytes);
+                    self.uncompressed_remaining_memory_in_bytes -= SegmentBuilder::get_memory_size();
+                    info!("Created segment. Remaining bytes: {}.", self.uncompressed_remaining_memory_in_bytes);
 
                     segment.insert_data(&data_point);
-                    self.data.insert(key, segment);
+                    self.uncompressed_data.insert(key, segment);
                 }
             }
             Err(e) => error!("Message could not be inserted into storage: {:?}", e),
@@ -137,9 +134,9 @@ impl StorageEngine {
     /// Remove the oldest finished segment from the compression queue and return it. Return `None`
     /// if the compression queue is empty.
     pub fn get_finished_segment(&mut self) -> Option<FinishedSegment> {
-        if let Some(finished_segment) = self.compression_queue.pop_front() {
+        if let Some(finished_segment) = self.finished_queue.pop_front() {
             // Add the memory size of the removed finished segment back to the remaining bytes.
-            self.remaining_memory_in_bytes +=
+            self.uncompressed_remaining_memory_in_bytes +=
                 finished_segment.uncompressed_segment.get_memory_size();
 
             Some(finished_segment)
@@ -164,7 +161,7 @@ impl StorageEngine {
             uncompressed_segment: Box::new(segment_builder),
         };
 
-        self.compression_queue.push_back(finished_segment);
+        self.finished_queue.push_back(finished_segment);
     }
 
     /// Spill the first in-memory finished segment in the compression queue. If no in-memory
@@ -173,14 +170,14 @@ impl StorageEngine {
         info!("Not enough memory to create segment. Spilling an already finished segment.");
 
         // Iterate through the finished segments to find a segment that is in memory.
-        for finished in self.compression_queue.iter_mut() {
+        for finished in self.finished_queue.iter_mut() {
             if let Ok(path) = finished.spill_to_parquet() {
                 // Add the size of the segment back to the remaining reserved bytes.
-                self.remaining_memory_in_bytes += SegmentBuilder::get_memory_size();
+                self.uncompressed_remaining_memory_in_bytes += SegmentBuilder::get_memory_size();
 
                 info!(
                     "Spilled the segment to '{}'. Remaining bytes: {}.",
-                    path, self.remaining_memory_in_bytes
+                    path, self.uncompressed_remaining_memory_in_bytes
                 );
                 return ();
             }
@@ -217,7 +214,7 @@ mod tests {
         let message = Message::new("ModelarDB/test", "invalid", 1);
         storage_engine.insert_message(message.clone());
 
-        assert!(storage_engine.data.is_empty());
+        assert!(storage_engine.uncompressed_data.is_empty());
     }
 
     #[test]
@@ -225,8 +222,8 @@ mod tests {
         let mut storage_engine = StorageEngine::new();
         let key = insert_generated_message(&mut storage_engine, "ModelarDB/test".to_owned());
 
-        assert!(storage_engine.data.contains_key(&key));
-        assert_eq!(storage_engine.data.get(&key).unwrap().get_length(), 1);
+        assert!(storage_engine.uncompressed_data.contains_key(&key));
+        assert_eq!(storage_engine.uncompressed_data.get(&key).unwrap().get_length(), 1);
     }
 
     #[test]
@@ -234,8 +231,8 @@ mod tests {
         let mut storage_engine = StorageEngine::new();
         let key = insert_multiple_messages(2, &mut storage_engine);
 
-        assert!(storage_engine.data.contains_key(&key));
-        assert_eq!(storage_engine.data.get(&key).unwrap().get_length(), 2);
+        assert!(storage_engine.uncompressed_data.contains_key(&key));
+        assert_eq!(storage_engine.uncompressed_data.get(&key).unwrap().get_length(), 2);
     }
 
     #[test]
@@ -265,11 +262,11 @@ mod tests {
     #[test]
     fn test_remaining_memory_decremented_when_creating_new_segment() {
         let mut storage_engine = StorageEngine::new();
-        let initial_remaining_memory = storage_engine.remaining_memory_in_bytes;
+        let initial_remaining_memory = storage_engine.uncompressed_remaining_memory_in_bytes;
 
         insert_generated_message(&mut storage_engine, "ModelarDB/test".to_owned());
 
-        assert!(initial_remaining_memory > storage_engine.remaining_memory_in_bytes);
+        assert!(initial_remaining_memory > storage_engine.uncompressed_remaining_memory_in_bytes);
     }
 
     #[test]
@@ -277,17 +274,17 @@ mod tests {
         let mut storage_engine = StorageEngine::new();
         let key = insert_multiple_messages(INITIAL_BUILDER_CAPACITY, &mut storage_engine);
 
-        let previous_remaining_memory = storage_engine.remaining_memory_in_bytes.clone();
+        let previous_remaining_memory = storage_engine.uncompressed_remaining_memory_in_bytes.clone();
         storage_engine.get_finished_segment();
 
-        assert!(previous_remaining_memory < storage_engine.remaining_memory_in_bytes);
+        assert!(previous_remaining_memory < storage_engine.uncompressed_remaining_memory_in_bytes);
     }
 
     #[test]
     #[should_panic(expected = "Not enough reserved memory to hold all necessary segment builders.")]
     fn test_panic_if_not_enough_reserved_memory() {
         let mut storage_engine = StorageEngine::new();
-        let reserved_memory = storage_engine.remaining_memory_in_bytes;
+        let reserved_memory = storage_engine.uncompressed_remaining_memory_in_bytes;
 
         // If there is enough reserved memory to hold n builders, we need to create n + 1 to panic.
         for i in 0..(reserved_memory / SegmentBuilder::get_memory_size()) + 1

--- a/server/src/storage/segment.rs
+++ b/server/src/storage/segment.rs
@@ -142,7 +142,7 @@ pub struct SpilledSegment {
 impl SpilledSegment {
     /// Spill the data in `batch` to a Parquet file, and return a spilled segment with the path.
     pub fn new(key: String, batch: RecordBatch) -> Self {
-        let folder_path = format!("uncompressed/{}", key);
+        let folder_path = format!("storage/{}/uncompressed", key);
         fs::create_dir_all(&folder_path);
 
         // Create a path that uses the first timestamp as the filename.

--- a/server/src/storage/segment.rs
+++ b/server/src/storage/segment.rs
@@ -282,7 +282,7 @@ mod tests {
     #[test]
     fn test_get_spilled_segment_memory_size() {
         let spilled_segment = SpilledSegment {
-            path: "path".to_string(),
+            path: "path".to_owned(),
         };
 
         assert_eq!(spilled_segment.get_memory_size(), 0)
@@ -291,9 +291,9 @@ mod tests {
     #[test]
     fn test_cannot_spill_already_spilled_segment() {
         let mut spilled_segment = SpilledSegment {
-            path: "path".to_string(),
+            path: "path".to_owned(),
         };
 
-        assert!(spilled_segment.spill_to_parquet("key".to_string()).is_err())
+        assert!(spilled_segment.spill_to_parquet("key".to_owned()).is_err())
     }
 }

--- a/server/src/storage/time_series.rs
+++ b/server/src/storage/time_series.rs
@@ -38,8 +38,8 @@ impl CompressedTimeSeries {
     }
 
     // TODO: Should return a compression error instead.
-    /// If `segment` has the correct schema, append it to the compressed data and return the size
-    /// of the segment in bytes, otherwise return `CompressionError`.
+    /// If `segment` has the correct schema, append it to the compressed data and return Ok,
+    /// otherwise return `CompressionError`.
     pub fn append_segment(&mut self, segment: RecordBatch) -> Result<usize, MiniModelarDBError> {
         // TODO: Check that the segment has the correct schema.
         // TODO: If so, append it to the compressed segments.

--- a/server/src/storage/time_series.rs
+++ b/server/src/storage/time_series.rs
@@ -15,7 +15,12 @@
 
 /// Support for managing multiple compressed segments from the same time series.
 
+use std::fs;
+
 use datafusion::arrow::record_batch::RecordBatch;
+
+use crate::errors::MiniModelarDBError;
+use crate::storage::write_batch_to_parquet;
 
 /// A single compressed time series, containing one or more compressed segments in order and providing
 /// functionality for appending more segments and saving all segments to a single Parquet file.
@@ -26,20 +31,41 @@ pub struct CompressedTimeSeries {
     size_in_bytes: usize,
 }
 
+// TODO: Since the size of compressed segments is not constant we need to have a private function in the struct to calculate the size in bytes.
 impl CompressedTimeSeries {
     // TODO: Should return a compression error instead.
-    /// If `segment` has the correct schema, append it to the compressed data and return Ok, otherwise return Err.
-    pub fn append_segment(segment: RecordBatch) -> Result<(), ()> {
+    /// If `segment` has the correct schema, append it to the compressed data and return the size
+    /// of the segment in bytes, otherwise return `CompressionError`.
+    pub fn append_segment(segment: RecordBatch) -> Result<usize, MiniModelarDBError> {
         // TODO: Check that the segment has the correct schema.
         // TODO: If so, append it to the compressed segments.
-        Ok(())
+        Ok(0)
     }
 
-    /// If the compressed segments is successfully saved to Parquet, return Ok, otherwise return Err.
+    // TODO: Should return error if there are not any segments to save.
+    /// If the compressed segments are successfully saved to Parquet, return Ok, otherwise return Err.
     pub fn save_time_series(key: String) -> Result<(), std::io::Error> {
         // TODO: Create the folder structure if it does not already exist.
         // TODO: Combine the segments into a single record batch.
         // TODO: Save the batch to a Parquet file.
+        let folder_path = format!("storage/{}/compressed", key);
+        fs::create_dir_all(&folder_path);
+
+        let path = format!("{}/{}.parquet", folder_path, first_timestamp);
+        write_batch_to_parquet(batch, path);
+
         Ok(())
     }
+
+    /// Return the size in bytes of `segment`.
+    fn get_size_of_segment(segment: RecordBatch) -> usize {
+        0
+    }
 }
+
+// TODO: Add a test for appending a segment with the correct schema.
+// TODO: Add a test for appending a segment with the wrong schema.
+// TODO: Add a test for getting the size of a record batch.
+// TODO: Add a test for updating the size of the compressed time series when appending.
+// TODO: Add a test for saving a compressed time series to disk (I/O).
+// TODO: Add a test for trying to save a compressed time series with no segments to disk.

--- a/server/src/storage/time_series.rs
+++ b/server/src/storage/time_series.rs
@@ -15,12 +15,9 @@
 
 /// Support for managing multiple compressed segments from the same time series.
 
-use std::fs;
-
 use datafusion::arrow::record_batch::RecordBatch;
 
 use crate::errors::MiniModelarDBError;
-use crate::storage::write_batch_to_parquet;
 
 /// A single compressed time series, containing one or more compressed segments in order and providing
 /// functionality for appending more segments and saving all segments to a single Parquet file.
@@ -28,7 +25,7 @@ pub struct CompressedTimeSeries {
     /// Compressed segments that make up the sequential compressed data of the time series.
     compressed_segments: Vec<RecordBatch>,
     /// Continuously updated total sum of the size of the compressed segments.
-    size_in_bytes: usize,
+    pub size_in_bytes: usize,
 }
 
 // TODO: Since the size of compressed segments is not constant we need to have a private function in the struct to calculate the size in bytes.
@@ -43,7 +40,7 @@ impl CompressedTimeSeries {
     // TODO: Should return a compression error instead.
     /// If `segment` has the correct schema, append it to the compressed data and return the size
     /// of the segment in bytes, otherwise return `CompressionError`.
-    pub fn append_segment(segment: RecordBatch) -> Result<usize, MiniModelarDBError> {
+    pub fn append_segment(&mut self, segment: RecordBatch) -> Result<usize, MiniModelarDBError> {
         // TODO: Check that the segment has the correct schema.
         // TODO: If so, append it to the compressed segments.
         Ok(0)
@@ -51,16 +48,10 @@ impl CompressedTimeSeries {
 
     // TODO: Should return error if there are not any segments to save.
     /// If the compressed segments are successfully saved to Parquet, return Ok, otherwise return Err.
-    pub fn save_to_parquet(key: String) -> Result<(), std::io::Error> {
+    pub fn save_to_parquet(&mut self, key: String) -> Result<(), std::io::Error> {
         // TODO: Create the folder structure if it does not already exist.
         // TODO: Combine the segments into a single record batch.
         // TODO: Save the batch to a Parquet file.
-        let folder_path = format!("storage/{}/compressed", key);
-        fs::create_dir_all(&folder_path);
-
-        let path = format!("{}/{}.parquet", folder_path, first_timestamp);
-        write_batch_to_parquet(batch, path);
-
         Ok(())
     }
 

--- a/server/src/storage/time_series.rs
+++ b/server/src/storage/time_series.rs
@@ -15,6 +15,7 @@
 
 /// Support for managing multiple compressed segments from the same time series.
 
+use datafusion::arrow::array::Array;
 use datafusion::arrow::record_batch::RecordBatch;
 
 use crate::errors::MiniModelarDBError;
@@ -28,7 +29,6 @@ pub struct CompressedTimeSeries {
     pub size_in_bytes: usize,
 }
 
-// TODO: Since the size of compressed segments is not constant we need to have a private function in the struct to calculate the size in bytes.
 impl CompressedTimeSeries {
     pub fn new() -> Self {
         Self {
@@ -37,13 +37,15 @@ impl CompressedTimeSeries {
         }
     }
 
-    // TODO: Should return a compression error instead.
     /// If `segment` has the correct schema, append it to the compressed data and return Ok,
     /// otherwise return `CompressionError`.
     pub fn append_segment(&mut self, segment: RecordBatch) -> Result<usize, MiniModelarDBError> {
         // TODO: Check that the segment has the correct schema.
         // TODO: If so, append it to the compressed segments.
-        Ok(0)
+        let segment_size = CompressedTimeSeries::get_size_of_segment(segment);
+        self.size_in_bytes += segment_size;
+
+        Ok(segment_size)
     }
 
     // TODO: Should return error if there are not any segments to save.
@@ -57,13 +59,47 @@ impl CompressedTimeSeries {
 
     /// Return the size in bytes of `segment`.
     fn get_size_of_segment(segment: RecordBatch) -> usize {
-        0
+        let mut total_size: usize = 0;
+
+        for column in segment.columns() {
+            total_size += column.data().get_array_memory_size()
+        }
+
+        total_size
     }
 }
 
-// TODO: Add a test for appending a segment with the correct schema.
-// TODO: Add a test for appending a segment with the wrong schema.
-// TODO: Add a test for getting the size of a record batch.
-// TODO: Add a test for updating the size of the compressed time series when appending.
-// TODO: Add a test for saving a compressed time series to disk (I/O).
-// TODO: Add a test for trying to save a compressed time series with no segments to disk.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_can_append_segment_with_valid_schema() {
+
+    }
+
+    #[test]
+    fn test_cannot_append_segment_with_invalid_schema() {
+
+    }
+
+    #[test]
+    fn test_compressed_time_series_size_updated_when_appending() {
+
+    }
+
+    #[test]
+    fn test_can_save_compressed_segments_to_parquet() {
+        // TODO: This requires I/O.
+    }
+
+    #[test]
+    fn test_cannot_save_empty_compressed_segments_to_parquet() {
+
+    }
+
+    #[test]
+    fn test_get_size_of_segment() {
+
+    }
+}

--- a/server/src/storage/time_series.rs
+++ b/server/src/storage/time_series.rs
@@ -37,15 +37,14 @@ impl CompressedTimeSeries {
         }
     }
 
-    /// If `segment` has the correct schema, append it to the compressed data and return Ok,
-    /// otherwise return `CompressionError`.
-    pub fn append_segment(&mut self, segment: RecordBatch) -> Result<usize, MiniModelarDBError> {
-        // TODO: Check that the segment has the correct schema.
-        // TODO: If so, append it to the compressed segments.
+    /// Append `segment` to the compressed data in the time series and return the size `segment` in bytes.
+    pub fn append_segment(&mut self, segment: RecordBatch) -> usize {
+        // TODO: Append it to the compressed segments.
+        // TODO: Maybe add a debug assert for the internal check of the schema.
         let segment_size = CompressedTimeSeries::get_size_of_segment(segment);
         self.size_in_bytes += segment_size;
 
-        Ok(segment_size)
+        segment_size
     }
 
     // TODO: Should return error if there are not any segments to save.
@@ -74,12 +73,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_can_append_segment_with_valid_schema() {
+    fn test_can_append_valid_compressed_segment() {
 
     }
 
     #[test]
-    fn test_cannot_append_segment_with_invalid_schema() {
+    fn test_cannot_append_invalid_compressed_segment() {
 
     }
 

--- a/server/src/storage/time_series.rs
+++ b/server/src/storage/time_series.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use datafusion::arrow::datatypes::{ArrowPrimitiveType, DataType, Field, Schema};
 use datafusion::arrow::record_batch::RecordBatch;
 
-use crate::storage::write_batch_to_parquet;
+use crate::storage::write_batch_to_apache_parquet;
 use crate::types::{ArrowTimestamp, ArrowValue, TimestampArray};
 
 /// A single compressed time series, containing one or more compressed segments and providing
@@ -59,7 +59,7 @@ impl CompressedTimeSeries {
 
     /// If the compressed segments are successfully saved to an Apache Parquet file, return Ok,
     /// otherwise return Err.
-    pub fn save_to_parquet(&mut self, key: String) -> Result<(), std::io::Error> {
+    pub fn save_to_apache_parquet(&mut self, key: String) -> Result<(), std::io::Error> {
         if self.compressed_segments.is_empty() {
             Err(std::io::Error::new(
                 Other,
@@ -80,7 +80,7 @@ impl CompressedTimeSeries {
             let start_times: &TimestampArray = batch.column(2).as_any().downcast_ref().unwrap();
             let path = format!("{}/{}.parquet", folder_path, start_times.value(0));
 
-            write_batch_to_parquet(batch, path.clone());
+            write_batch_to_apache_parquet(batch, path.clone());
 
             Ok(())
         }
@@ -150,9 +150,9 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_save_empty_compressed_segments_to_parquet() {
+    fn test_cannot_save_empty_compressed_segments_to_apache_parquet() {
         let mut empty_time_series = CompressedTimeSeries::new();
-        let result = empty_time_series.save_to_parquet("key".to_owned());
+        let result = empty_time_series.save_to_apache_parquet("key".to_owned());
 
         assert!(result.is_err());
     }

--- a/server/src/storage/time_series.rs
+++ b/server/src/storage/time_series.rs
@@ -33,6 +33,13 @@ pub struct CompressedTimeSeries {
 
 // TODO: Since the size of compressed segments is not constant we need to have a private function in the struct to calculate the size in bytes.
 impl CompressedTimeSeries {
+    pub fn new() -> Self {
+        Self {
+            compressed_segments: Vec::new(),
+            size_in_bytes: 0,
+        }
+    }
+
     // TODO: Should return a compression error instead.
     /// If `segment` has the correct schema, append it to the compressed data and return the size
     /// of the segment in bytes, otherwise return `CompressionError`.
@@ -44,7 +51,7 @@ impl CompressedTimeSeries {
 
     // TODO: Should return error if there are not any segments to save.
     /// If the compressed segments are successfully saved to Parquet, return Ok, otherwise return Err.
-    pub fn save_time_series(key: String) -> Result<(), std::io::Error> {
+    pub fn save_to_parquet(key: String) -> Result<(), std::io::Error> {
         // TODO: Create the folder structure if it does not already exist.
         // TODO: Combine the segments into a single record batch.
         // TODO: Save the batch to a Parquet file.

--- a/server/src/storage/time_series.rs
+++ b/server/src/storage/time_series.rs
@@ -62,7 +62,7 @@ impl CompressedTimeSeries {
         if self.compressed_segments.is_empty() {
             Err(std::io::Error::new(
                 Other,
-                "The time series does not contain any compressed data.",
+                "The compressed time series does not contain any compressed data.",
             ))
         } else {
             // Combine the segments into a single record batch.

--- a/server/src/storage/time_series.rs
+++ b/server/src/storage/time_series.rs
@@ -35,7 +35,7 @@ impl CompressedTimeSeries {
         Ok(())
     }
 
-    /// If the compressed segments can be successfully saved to Parquet, return Ok, otherwise return Err.
+    /// If the compressed segments is successfully saved to Parquet, return Ok, otherwise return Err.
     pub fn save_time_series(key: String) -> Result<(), std::io::Error> {
         // TODO: Create the folder structure if it does not already exist.
         // TODO: Combine the segments into a single record batch.

--- a/server/src/storage/time_series.rs
+++ b/server/src/storage/time_series.rs
@@ -13,12 +13,19 @@
  * limitations under the License.
  */
 
-/// Support for managing multiple compressed segments from the same time series.
+//! Support for managing multiple compressed segments from the same time series.
 
-use datafusion::arrow::array::Array;
+use std::fs;
+use std::io::ErrorKind::Other;
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Array, UInt8Array};
+use datafusion::arrow::datatypes::DataType::{Float32, List, UInt8};
+use datafusion::arrow::datatypes::{ArrowPrimitiveType, Field, Schema};
 use datafusion::arrow::record_batch::RecordBatch;
 
-use crate::errors::MiniModelarDBError;
+use crate::storage::write_batch_to_parquet;
+use crate::types::{ArrowTimestamp, ArrowValue, TimestampArray};
 
 /// A single compressed time series, containing one or more compressed segments in order and providing
 /// functionality for appending more segments and saving all segments to a single Parquet file.
@@ -37,27 +44,45 @@ impl CompressedTimeSeries {
         }
     }
 
+    // TODO: Maybe use debug assert to check that the schema is correct.
     /// Append `segment` to the compressed data in the time series and return the size `segment` in bytes.
     pub fn append_segment(&mut self, segment: RecordBatch) -> usize {
-        // TODO: Append it to the compressed segments.
-        // TODO: Maybe add a debug assert for the internal check of the schema.
-        let segment_size = CompressedTimeSeries::get_size_of_segment(segment);
+        let segment_size = CompressedTimeSeries::get_size_of_segment(&segment);
+
+        self.compressed_segments.push(segment);
         self.size_in_bytes += segment_size;
 
         segment_size
     }
 
-    // TODO: Should return error if there are not any segments to save.
     /// If the compressed segments are successfully saved to Parquet, return Ok, otherwise return Err.
     pub fn save_to_parquet(&mut self, key: String) -> Result<(), std::io::Error> {
-        // TODO: Create the folder structure if it does not already exist.
-        // TODO: Combine the segments into a single record batch.
-        // TODO: Save the batch to a Parquet file.
-        Ok(())
+        if self.compressed_segments.is_empty() {
+            Err(std::io::Error::new(
+                Other,
+                "The time series does not contain any compressed data.",
+            ))
+        } else {
+            // Combine the segments into a single record batch.
+            let schema = CompressedTimeSeries::get_compressed_segment_schema();
+            let batch = RecordBatch::concat(&Arc::new(schema), &*self.compressed_segments).unwrap();
+
+            // Create the folder structure if it does not already exist.
+            let folder_path = format!("storage/{}/compressed", key);
+            fs::create_dir_all(&folder_path)?;
+
+            // Create a path that uses the first timestamp as the filename.
+            let timestamps: &TimestampArray = batch.column(0).as_any().downcast_ref().unwrap();
+            let path = format!("{}/{}.parquet", folder_path, timestamps.value(0));
+
+            write_batch_to_parquet(batch, path.clone());
+
+            Ok(())
+        }
     }
 
     /// Return the size in bytes of `segment`.
-    fn get_size_of_segment(segment: RecordBatch) -> usize {
+    fn get_size_of_segment(segment: &RecordBatch) -> usize {
         let mut total_size: usize = 0;
 
         for column in segment.columns() {
@@ -66,6 +91,23 @@ impl CompressedTimeSeries {
 
         total_size
     }
+
+    /// Return the record batch schema used for compressed segments.
+    fn get_compressed_segment_schema() -> Schema {
+        let timestamp_field = Field::new("timestamp", UInt8, false);
+        let value_field = Field::new("value", UInt8, false);
+
+        Schema::new(vec![
+            Field::new("model_type_id", UInt8, false),
+            Field::new("timestamps", List(Box::new(timestamp_field)), false),
+            Field::new("start_time", ArrowTimestamp::DATA_TYPE, false),
+            Field::new("end_time", ArrowTimestamp::DATA_TYPE, false),
+            Field::new("values", List(Box::new(value_field)), false),
+            Field::new("min_value", ArrowValue::DATA_TYPE, false),
+            Field::new("max_value", ArrowValue::DATA_TYPE, false),
+            Field::new("error", Float32, false),
+        ])
+    }
 }
 
 #[cfg(test)]
@@ -73,19 +115,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_can_append_valid_compressed_segment() {
-
-    }
+    fn test_can_append_valid_compressed_segment() {}
 
     #[test]
-    fn test_cannot_append_invalid_compressed_segment() {
-
-    }
+    fn test_cannot_append_invalid_compressed_segment() {}
 
     #[test]
-    fn test_compressed_time_series_size_updated_when_appending() {
-
-    }
+    fn test_compressed_time_series_size_updated_when_appending() {}
 
     #[test]
     fn test_can_save_compressed_segments_to_parquet() {
@@ -93,12 +129,8 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_save_empty_compressed_segments_to_parquet() {
-
-    }
+    fn test_cannot_save_empty_compressed_segments_to_parquet() {}
 
     #[test]
-    fn test_get_size_of_segment() {
-
-    }
+    fn test_get_size_of_segment() {}
 }

--- a/server/src/storage/time_series.rs
+++ b/server/src/storage/time_series.rs
@@ -1,0 +1,45 @@
+/* Copyright 2022 The MiniModelarDB Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// Support for managing multiple compressed segments from the same time series.
+
+use datafusion::arrow::record_batch::RecordBatch;
+
+/// A single compressed time series, containing one or more compressed segments in order and providing
+/// functionality for appending more segments and saving all segments to a single Parquet file.
+pub struct CompressedTimeSeries {
+    /// Compressed segments that make up the sequential compressed data of the time series.
+    compressed_segments: Vec<RecordBatch>,
+    /// Continuously updated total sum of the size of the compressed segments.
+    size_in_bytes: usize,
+}
+
+impl CompressedTimeSeries {
+    // TODO: Should return a compression error instead.
+    /// If `segment` has the correct schema, append it to the compressed data and return Ok, otherwise return Err.
+    pub fn append_segment(segment: RecordBatch) -> Result<(), ()> {
+        // TODO: Check that the segment has the correct schema.
+        // TODO: If so, append it to the compressed segments.
+        Ok(())
+    }
+
+    /// If the compressed segments can be successfully saved to Parquet, return Ok, otherwise return Err.
+    pub fn save_time_series(key: String) -> Result<(), std::io::Error> {
+        // TODO: Create the folder structure if it does not already exist.
+        // TODO: Combine the segments into a single record batch.
+        // TODO: Save the batch to a Parquet file.
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR includes an extension to the functionality of the storage engine to avoid unnecessary I/O and very small files. Previously each compressed segment was saved in a separate Parquet file but now the storage engine stores the compressed data in memory if possible and saves compressed data in batches when necessary. 