### PR TITLE
Refactor catalog and main

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The following commands are for Ubuntu Server. However, equivalent commands shoul
    * Debug Build: `cargo build`
    * Release Build: `cargo build --release`
    * Run Tests: `cargo test`
-   * Run Server: `cargo run --bin mmdbd absolute_path_to_data_folder`
+   * Run Server: `cargo run --bin mmdbd path_to_data_folder`
    * Run Client: `cargo run --bin mmdb [server_address] [query_file]`
 5. Move `mmdbd` and `mmdb` from the `target` directory to any directory.
 

--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -17,7 +17,7 @@ use std::fs::{read_dir, DirEntry};
 use std::io::Read;
 use std::str;
 use std::sync::Arc;
-use std::{fs::File, path::Path};
+use std::{fs::File, fs::OpenOptions, path::Path};
 
 use datafusion::arrow::array::{
     Array, ArrayRef, BinaryArray, Int32Array, Int32Builder, StringBuilder,
@@ -145,7 +145,11 @@ fn is_dir_entry_a_table(dir_entry: &DirEntry) -> bool {
 }
 
 fn is_dir_entry_a_parquet_file(dir_entry: &DirEntry) -> bool {
-    let mut file = File::open(dir_entry.path()).unwrap();
+    // Write permissions are required on Microsoft Windows.
+    let mut file = OpenOptions::new()
+        .write(true)
+        .open(dir_entry.path())
+        .unwrap();
     let mut magic_bytes = vec![0u8; 4];
     let _ = file.read_exact(&mut magic_bytes);
     magic_bytes == [80, 65, 82, 49] //Magic bytes PAR1

--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -45,7 +45,7 @@ pub struct Catalog {
 impl Catalog {
     /// Scan `data_folder` for tables and model tables and construct a `Catalog`
     /// that contains the metadata necessary to query these tables.
-    pub fn new(data_folder: &str) -> Result<Self, Error> {
+    pub fn try_new(data_folder: &str) -> Result<Self, Error> {
         let mut table_metadata = vec![];
         let mut model_table_metadata = vec![];
         let model_table_legacy_segment_file_schema = Arc::new(Schema::new(vec![

--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -302,7 +302,7 @@ impl ModelTableMetadata {
             }))
         } else {
             Err(ParquetError::General(format!(
-                "Unable to read metadata for {}.",
+                "Unable to read metadata for folder '{}'.",
                 folder_name
             )))
         }
@@ -336,7 +336,7 @@ impl ModelTableMetadata {
         let mut arrow_reader = ParquetFileArrowReader::new(Arc::new(reader));
         let mut record_batch_reader = arrow_reader.get_record_reader(row_count)?;
         let rows = record_batch_reader.next().ok_or_else(|| {
-            ParquetError::General(format!("No metadata exists for {}.", *table_name))
+            ParquetError::General(format!("No metadata exists for table '{}'.", *table_name))
         })??;
         Ok(rows)
     }

--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -209,7 +209,7 @@ pub struct TableMetadata {
     /// Name of the table.
     pub name: String,
     /// Location of the table's file or folder in an `ObjectStore`.
-    pub folder: ObjectStorePath,
+    pub folder: String, // Not ObjectStorePath as register_parquet expects &str
 }
 
 impl TableMetadata {
@@ -220,8 +220,7 @@ impl TableMetadata {
             file_name
         };
 
-        let folder = ObjectStorePath::parse(path).unwrap();
-        Self { name, folder }
+        Self { name, folder: path }
     }
 }
 

--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -34,13 +34,6 @@ use datafusion::parquet::file::reader::{FileReader, SerializedFileReader};
 use datafusion::parquet::record::RowAccessor;
 use tracing::{error, info};
 
-/// Metadata for the tables and model tables in the data folder.
-#[derive(Debug)]
-pub struct Catalog {
-    pub table_metadata: Vec<TableMetadata>,
-    pub model_table_metadata: Vec<Arc<ModelTableMetadata>>,
-}
-
 /// Metadata for a table.
 #[derive(Debug)]
 pub struct TableMetadata {
@@ -71,7 +64,71 @@ pub struct ModelTableMetadata {
     pub denormalized_dimensions: Vec<ArrayRef>,
 }
 
+/// Metadata for the tables and model tables in the data folder.
+#[derive(Debug)]
+pub struct Catalog {
+    pub table_metadata: Vec<TableMetadata>,
+    pub model_table_metadata: Vec<Arc<ModelTableMetadata>>,
+}
+
 impl Catalog {
+    /// Scan `data_folder` for tables and model tables and construct a `Catalog`
+    /// that contains the metadata necessary to query these tables.
+    pub fn new(data_folder: &str) -> Self {
+        let mut table_metadata = vec![];
+        let mut model_table_metadata = vec![];
+        let model_table_segment_group_file_schema = Arc::new(Schema::new(vec![
+            Field::new("gid", DataType::Int32, false),
+            Field::new("start_time", DataType::Int64, false),
+            Field::new("end_time", DataType::Int64, false),
+            Field::new("mtid", DataType::Int32, false),
+            Field::new("model", DataType::Binary, false),
+            Field::new("gaps", DataType::Binary, false),
+        ]));
+
+        if let Ok(data_folder) = read_dir(data_folder) {
+            for dir_entry in data_folder {
+                if let Ok(dir_entry) = dir_entry {
+                    let dir_entry_path = dir_entry.path();
+                    if let Some(path) = dir_entry_path.to_str() {
+                        let file_name = dir_entry.file_name().to_str().unwrap().to_string();
+                        // HACK: workaround for datafusion 8.0.0 lowercasing table names in queries.
+                        let normalized_file_name = file_name.to_ascii_lowercase();
+                        if Self::is_dir_entry_a_table(&dir_entry) {
+                            table_metadata
+                                .push(Self::new_table_metadata(normalized_file_name, path.to_string()));
+                            info!("Initialized table {}.", path);
+                        } else if Self::is_dir_entry_a_model_table(&dir_entry) {
+                            if let Ok(mtd) = Self::read_model_table_metadata(
+                                normalized_file_name,
+                                path.to_string(),
+                                &model_table_segment_group_file_schema,
+                            ) {
+                                model_table_metadata.push(mtd);
+                                info!("Initialized model table {}.", path);
+                            } else {
+                                error!("Unsupported model table {}.", path);
+                            }
+                        } else {
+                            error!("Unsupported file or folder {}.", path);
+                        }
+                    } else {
+                        error!("Name of file or folder is not UTF-8.");
+                    }
+                } else {
+                    let message = dir_entry.unwrap_err().to_string();
+                    error!("Unable to read file or folder {}.", &message);
+                }
+            }
+        } else {
+            error!("Unable to open data folder {}.", &data_folder);
+        }
+        Catalog {
+            table_metadata,
+            model_table_metadata,
+        }
+    }
+
     /// Return the name of all tables and model tables in the `Catalog`.
     pub fn table_names(&self) -> Vec<String> {
         let mut table_names: Vec<String> = vec![];
@@ -84,239 +141,183 @@ impl Catalog {
         }
         table_names
     }
-}
 
-/// Scan `data_folder` for tables and model tables and construct a `Catalog`
-/// that contains the metadata necessary to query these tables.
-pub fn new(data_folder: &str) -> Catalog {
-    let mut table_metadata = vec![];
-    let mut model_table_metadata = vec![];
-    let model_table_segment_group_file_schema = Arc::new(Schema::new(vec![
-        Field::new("gid", DataType::Int32, false),
-        Field::new("start_time", DataType::Int64, false),
-        Field::new("end_time", DataType::Int64, false),
-        Field::new("mtid", DataType::Int32, false),
-        Field::new("model", DataType::Binary, false),
-        Field::new("gaps", DataType::Binary, false),
-    ]));
-
-    if let Ok(data_folder) = read_dir(data_folder) {
-        for dir_entry in data_folder {
-            if let Ok(dir_entry) = dir_entry {
-                let dir_entry_path = dir_entry.path();
-                if let Some(path) = dir_entry_path.to_str() {
-                    let file_name = dir_entry.file_name().to_str().unwrap().to_string();
-                    // HACK: workaround for datafusion 8.0.0 lowercasing table names in queries.
-                    let normalized_file_name = file_name.to_ascii_lowercase();
-                    if is_dir_entry_a_table(&dir_entry) {
-                        table_metadata
-                            .push(new_table_metadata(normalized_file_name, path.to_string()));
-                        info!("Initialized table {}.", path);
-                    } else if is_dir_entry_a_model_table(&dir_entry) {
-                        if let Ok(mtd) = read_model_table_metadata(
-                            normalized_file_name,
-                            path.to_string(),
-                            &model_table_segment_group_file_schema,
-                        ) {
-                            model_table_metadata.push(mtd);
-                            info!("Initialized model table {}.", path);
-                        } else {
-                            error!("Unsupported model table {}.", path);
-                        }
-                    } else {
-                        error!("Unsupported file or folder {}.", path);
-                    }
+    /// Return `true` if `dir_entry` is a table, otherwise `false`.
+    fn is_dir_entry_a_table(dir_entry: &DirEntry) -> bool {
+        // TODO: check the files for tables and model tables have the correct schema.
+        if let Ok(metadata) = dir_entry.metadata() {
+            if metadata.is_file() {
+                Self::is_dir_entry_a_parquet_file(dir_entry)
+            } else if metadata.is_dir() {
+                if let Ok(mut data_folder) = read_dir(dir_entry.path()) {
+                    data_folder.all(|result| {
+                        result.is_ok() && Self::is_dir_entry_a_parquet_file(&result.unwrap())
+                    })
                 } else {
-                    error!("Name of file or folder is not UTF-8.");
+                    false
                 }
-            } else {
-                let message = dir_entry.unwrap_err().to_string();
-                error!("Unable to read file or folder {}.", &message);
-            }
-        }
-    } else {
-        error!("Unable to open data folder {}.", &data_folder);
-    }
-    Catalog {
-        table_metadata,
-        model_table_metadata,
-    }
-}
-
-/// Return `true` if `dir_entry` is a table, otherwise `false`.
-fn is_dir_entry_a_table(dir_entry: &DirEntry) -> bool {
-    // TODO: check the files for tables and model tables have the correct schema.
-    if let Ok(metadata) = dir_entry.metadata() {
-        if metadata.is_file() {
-            is_dir_entry_a_parquet_file(dir_entry)
-        } else if metadata.is_dir() {
-            if let Ok(mut data_folder) = read_dir(dir_entry.path()) {
-                data_folder
-                    .all(|result| result.is_ok() && is_dir_entry_a_parquet_file(&result.unwrap()))
             } else {
                 false
             }
         } else {
             false
         }
-    } else {
-        false
     }
-}
 
-/// Return `true` if `dir_entry` is an Apache Parquet file, otherwise `false`.
-fn is_dir_entry_a_parquet_file(dir_entry: &DirEntry) -> bool {
-    // Write permissions are required on Microsoft Windows.
-    let mut file = OpenOptions::new()
-        .write(true)
-        .open(dir_entry.path())
-        .unwrap();
-    let mut magic_bytes = vec![0u8; 4];
-    let _ = file.read_exact(&mut magic_bytes);
-    magic_bytes == [80, 65, 82, 49] //Magic bytes PAR1
-}
-
-fn new_table_metadata(file_name: String, path: String) -> TableMetadata {
-    let name = if let Some(index) = file_name.find('.') {
-        file_name[0..index].to_string()
-    } else {
-        file_name
-    };
-
-    TableMetadata { name, path }
-}
-
-/// Return `true` if `dir_entry` is a model table, otherwise `false`.
-fn is_dir_entry_a_model_table(dir_entry: &DirEntry) -> bool {
-    if let Ok(metadata) = dir_entry.metadata() {
-        if metadata.is_dir() {
-            return ["model_type.parquet", "time_series.parquet", "segment"]
-                .iter()
-                .map(|required_file_name| {
-                    let mut path = dir_entry.path();
-                    path.push(required_file_name);
-                    Path::new(&path).exists()
-                })
-                .all(|exists| exists);
-        }
+    /// Return `true` if `dir_entry` is an Apache Parquet file, otherwise `false`.
+    fn is_dir_entry_a_parquet_file(dir_entry: &DirEntry) -> bool {
+        // Write permissions are required on Microsoft Windows.
+        let mut file = OpenOptions::new()
+            .write(true)
+            .open(dir_entry.path())
+            .unwrap();
+        let mut magic_bytes = vec![0u8; 4];
+        let _ = file.read_exact(&mut magic_bytes);
+        magic_bytes == [80, 65, 82, 49] //Magic bytes PAR1
     }
-    false
-}
 
-/// Read and check the metadata for a model table. Return `ParquetError` if the
-/// metadata cannot be read or if the model table uses unsupported model types.
-fn read_model_table_metadata(
-    table_name: String,
-    table_folder: String,
-    segment_group_file_schema: &Arc<Schema>,
-) -> Result<Arc<ModelTableMetadata>, ParquetError> {
-    // Ensure only supported model types are used.
-    let model_types_file = table_folder.clone() + "/model_type.parquet";
-    let path = Path::new(&model_types_file);
-    if let Ok(file) = File::open(&path) {
-        let reader = SerializedFileReader::new(file)?;
-        let rows = reader.get_row_iter(None)?;
-        for row in rows {
-            let mtid = row.get_int(0)?;
-            let name = row.get_bytes(1)?.as_utf8()?;
-            match (mtid, name) {
-                (1, "dk.aau.modelardb.core.models.UncompressedModelType") => (),
-                (2, "dk.aau.modelardb.core.models.PMC_MeanModelType") => (),
-                (3, "dk.aau.modelardb.core.models.SwingFilterModelType") => (),
-                (4, "dk.aau.modelardb.core.models.FacebookGorillaModelType") => (),
-                _ => return Err(ParquetError::General("unsupported model type".to_string())),
+    fn new_table_metadata(file_name: String, path: String) -> TableMetadata {
+        let name = if let Some(index) = file_name.find('.') {
+            file_name[0..index].to_string()
+        } else {
+            file_name
+        };
+
+        TableMetadata { name, path }
+    }
+
+    /// Return `true` if `dir_entry` is a model table, otherwise `false`.
+    fn is_dir_entry_a_model_table(dir_entry: &DirEntry) -> bool {
+        if let Ok(metadata) = dir_entry.metadata() {
+            if metadata.is_dir() {
+                return ["model_type.parquet", "time_series.parquet", "segment"]
+                    .iter()
+                    .map(|required_file_name| {
+                        let mut path = dir_entry.path();
+                        path.push(required_file_name);
+                        Path::new(&path).exists()
+                    })
+                    .all(|exists| exists);
             }
         }
+        false
     }
 
-    // Read time series metadata.
-    // TODO: read tids and gids so data from time series groups can be correctly decompressed.
-    let time_series_file = table_folder.clone() + "/time_series.parquet";
-    let path = Path::new(&time_series_file);
-    if let Ok(file) = File::open(&path) {
-        let reader = SerializedFileReader::new(file)?;
-        let parquet_metadata = reader.metadata();
-        let row_count = parquet_metadata
-            .row_groups()
-            .iter()
-            .map(|rg| rg.num_rows())
-            .sum::<i64>() as usize;
+    /// Read and check the metadata for a model table. Return `ParquetError` if the
+    /// metadata cannot be read or if the model table uses unsupported model types.
+    fn read_model_table_metadata(
+        table_name: String,
+        table_folder: String,
+        segment_group_file_schema: &Arc<Schema>,
+    ) -> Result<Arc<ModelTableMetadata>, ParquetError> {
+        // Ensure only supported model types are used.
+        let model_types_file = table_folder.clone() + "/model_type.parquet";
+        let path = Path::new(&model_types_file);
+        if let Ok(file) = File::open(&path) {
+            let reader = SerializedFileReader::new(file)?;
+            let rows = reader.get_row_iter(None)?;
+            for row in rows {
+                let mtid = row.get_int(0)?;
+                let name = row.get_bytes(1)?.as_utf8()?;
+                match (mtid, name) {
+                    (1, "dk.aau.modelardb.core.models.UncompressedModelType") => (),
+                    (2, "dk.aau.modelardb.core.models.PMC_MeanModelType") => (),
+                    (3, "dk.aau.modelardb.core.models.SwingFilterModelType") => (),
+                    (4, "dk.aau.modelardb.core.models.FacebookGorillaModelType") => (),
+                    _ => return Err(ParquetError::General("unsupported model type".to_string())),
+                }
+            }
+        }
 
-        let mut arrow_reader = ParquetFileArrowReader::new(Arc::new(reader));
-        let mut record_batch_reader = arrow_reader.get_record_reader(row_count)?;
-        let rows = record_batch_reader.next().unwrap()?; //TODO: handle empty Parquet files
+        // Read time series metadata.
+        // TODO: read tids and gids so data from time series groups can be correctly decompressed.
+        let time_series_file = table_folder.clone() + "/time_series.parquet";
+        let path = Path::new(&time_series_file);
+        if let Ok(file) = File::open(&path) {
+            let reader = SerializedFileReader::new(file)?;
+            let parquet_metadata = reader.metadata();
+            let row_count = parquet_metadata
+                .row_groups()
+                .iter()
+                .map(|rg| rg.num_rows())
+                .sum::<i64>() as usize;
 
-        let sampling_intervals = extract_and_shift_int32_column(&rows, 2)?;
-        let denormalized_dimensions = extract_and_shift_denormalized_dimensions(&rows, 4)?;
+            let mut arrow_reader = ParquetFileArrowReader::new(Arc::new(reader));
+            let mut record_batch_reader = arrow_reader.get_record_reader(row_count)?;
+            let rows = record_batch_reader.next().unwrap()?; //TODO: handle empty Parquet files
 
-        Ok(Arc::new(ModelTableMetadata {
-            name: table_name,
-            segment_folder: table_folder + "/segment",
-            segment_group_file_schema: segment_group_file_schema.clone(),
-            sampling_intervals,
-            denormalized_dimensions,
-        }))
-    } else {
-        Err(ParquetError::General(format!(
-            "unable to read metadata for {}",
-            table_name
-        )))
+            let sampling_intervals = Self::extract_and_shift_int32_column(&rows, 2)?;
+            let denormalized_dimensions = Self::extract_and_shift_denormalized_dimensions(&rows, 4)?;
+
+            Ok(Arc::new(ModelTableMetadata {
+                name: table_name,
+                segment_folder: table_folder + "/segment",
+                segment_group_file_schema: segment_group_file_schema.clone(),
+                sampling_intervals,
+                denormalized_dimensions,
+            }))
+        } else {
+            Err(ParquetError::General(format!(
+                "unable to read metadata for {}",
+                table_name
+            )))
+        }
     }
-}
 
-/// Read the array at `column_index` from `rows`, cast it to `Int32Array`, and
-/// increase the index of all values in the array with one.
-fn extract_and_shift_int32_column(
-    rows: &RecordBatch,
-    column_index: usize,
-) -> Result<Int32Array, ParquetError> {
-    let column = rows
-        .column(column_index)
-        .as_any()
-        .downcast_ref::<Int32Array>()
-        .unwrap()
-        .values();
-    let mut shifted_column = Int32Builder::new(column.len() + 1);
-    shifted_column.append_value(-1)?; //-1 is stored at index 0 as ids starting at 1 is used for lookup
-    shifted_column.append_slice(column)?;
-    Ok(shifted_column.finish())
-}
-
-/// Read the arrays from `first_column_index` to `rows.num_columns()` from
-/// `rows`, cast them to `BinaryArray`, and increase the index of all values in
-/// the arrays with one.
-fn extract_and_shift_denormalized_dimensions(
-    rows: &RecordBatch,
-    first_column_index: usize,
-) -> Result<Vec<ArrayRef>, ParquetError> {
-    let mut denormalized_dimensions: Vec<ArrayRef> = vec![];
-    for level_column_index in first_column_index..rows.num_columns() {
-        //TODO: support dimensions with levels that are not strings?
-        let level = extract_and_shift_text_column(rows, level_column_index)?;
-        denormalized_dimensions.push(level);
+    /// Read the array at `column_index` from `rows`, cast it to `Int32Array`, and
+    /// increase the index of all values in the array with one.
+    fn extract_and_shift_int32_column(
+        rows: &RecordBatch,
+        column_index: usize,
+    ) -> Result<Int32Array, ParquetError> {
+        let column = rows
+            .column(column_index)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap()
+            .values();
+        let mut shifted_column = Int32Builder::new(column.len() + 1);
+        shifted_column.append_value(-1)?; //-1 is stored at index 0 as ids starting at 1 is used for lookup
+        shifted_column.append_slice(column)?;
+        Ok(shifted_column.finish())
     }
-    Ok(denormalized_dimensions)
-}
 
-/// Read the array at `column_index` from `rows`, cast it to `BinaryArray`, and
-/// increase the index of all values in the array with one.
-fn extract_and_shift_text_column(
-    rows: &RecordBatch,
-    column_index: usize,
-) -> Result<ArrayRef, ParquetError> {
-    let schema = rows.schema();
-    let name = schema.field(column_index).name();
-    let column = rows
-        .column(column_index)
-        .as_any()
-        .downcast_ref::<BinaryArray>()
-        .unwrap();
-    let mut shifted_column =
-        StringBuilder::with_capacity(column.len(), column.get_buffer_memory_size());
-    shifted_column.append_value(name)?; //The level's name is stored at index 0 as ids starting at 1 is used for lookup
-    for member_as_bytes in column {
-        let member_as_str = str::from_utf8(member_as_bytes.unwrap())?;
-        shifted_column.append_value(member_as_str)?;
+    /// Read the arrays from `first_column_index` to `rows.num_columns()` from
+    /// `rows`, cast them to `BinaryArray`, and increase the index of all values in
+    /// the arrays with one.
+    fn extract_and_shift_denormalized_dimensions(
+        rows: &RecordBatch,
+        first_column_index: usize,
+    ) -> Result<Vec<ArrayRef>, ParquetError> {
+        let mut denormalized_dimensions: Vec<ArrayRef> = vec![];
+        for level_column_index in first_column_index..rows.num_columns() {
+            //TODO: support dimensions with levels that are not strings?
+            let level = Self::extract_and_shift_text_column(rows, level_column_index)?;
+            denormalized_dimensions.push(level);
+        }
+        Ok(denormalized_dimensions)
     }
-    Ok(Arc::new(shifted_column.finish()))
+
+    /// Read the array at `column_index` from `rows`, cast it to `BinaryArray`, and
+    /// increase the index of all values in the array with one.
+    fn extract_and_shift_text_column(
+        rows: &RecordBatch,
+        column_index: usize,
+    ) -> Result<ArrayRef, ParquetError> {
+        let schema = rows.schema();
+        let name = schema.field(column_index).name();
+        let column = rows
+            .column(column_index)
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .unwrap();
+        let mut shifted_column =
+            StringBuilder::with_capacity(column.len(), column.get_buffer_memory_size());
+        shifted_column.append_value(name)?; //The level's name is stored at index 0 as ids starting at 1 is used for lookup
+        for member_as_bytes in column {
+            let member_as_str = str::from_utf8(member_as_bytes.unwrap())?;
+            shifted_column.append_value(member_as_str)?;
+        }
+        Ok(Arc::new(shifted_column.finish()))
+    }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -101,7 +101,7 @@ fn register_tables(runtime: &Runtime, session: &mut SessionContext, catalog: &mu
     catalog.table_metadata.retain(|table_metadata| {
         let result = runtime.block_on(session.register_parquet(
             &table_metadata.name,
-            &table_metadata.folder,
+            &table_metadata.path,
             ParquetReadOptions::default(),
         ));
         check_if_ok_otherwse_log_error("table", &table_metadata.name, result)

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -144,7 +144,7 @@ fn register_tables_and_model_tables(
     });
 }
 
-/// Check if the `result`from a table or model table initialization is an
+/// Check if the `result` from a table or model table initialization is an
 /// `Error`, if so log an error message containing `table_type` and `name` and
 /// return `false`, otherwise return `true`.
 fn check_if_table_or_model_table_is_initialized_otherwise_log_error<T>(

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -80,8 +80,8 @@ fn main() -> Result<(), String> {
     } else {
         // The errors are consciously ignored as the program is terminating.
         let binary_path = std::env::current_exe().unwrap();
-        let binary_name = binary_path.file_name().unwrap();
-        eprintln!("Usage: {} data_folder.", binary_name.to_str().unwrap());
+        let binary_name = binary_path.file_name().unwrap().to_str().unwrap();
+        eprintln!("Usage: {} absolute_path_to_data_folder.", binary_name);
     }
     Ok(())
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -42,7 +42,7 @@ static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 
 /** Public Types **/
 pub struct Context {
-    catalog: catalog::Catalog,
+    catalog: Catalog,
     runtime: Runtime,
     session: SessionContext,
 }
@@ -57,7 +57,7 @@ fn main() {
     args.next(); // Skip executable.
     if let Some(data_folder) = args.next() {
         // Build Context.
-        let catalog = catalog::new(&data_folder);
+        let catalog = Catalog::new(&data_folder);
         let runtime = Runtime::new().unwrap();
         let mut session = create_session_context();
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -57,7 +57,7 @@ fn main() {
     args.next(); // Skip executable.
     if let Some(data_folder) = args.next() {
         // Build Context.
-        let catalog = Catalog::new(&data_folder);
+        let catalog = Catalog::new(&data_folder).unwrap(); //TODO
         let runtime = Runtime::new().unwrap();
         let mut session = create_session_context();
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -81,7 +81,7 @@ fn main() -> Result<(), String> {
         // The errors are consciously ignored as the program is terminating.
         let binary_path = std::env::current_exe().unwrap();
         let binary_name = binary_path.file_name().unwrap().to_str().unwrap();
-        eprintln!("Usage: {} absolute_path_to_data_folder.", binary_name);
+        eprintln!("Usage: {} path_to_data_folder.", binary_name);
     }
     Ok(())
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -95,7 +95,7 @@ async fn register_tables(session: &mut SessionContext, catalog: &Catalog) {
         if session
             .register_parquet(
                 &table_metadata.name,
-                &table_metadata.path,
+                table_metadata.folder.as_ref(),
                 ParquetReadOptions::default(),
             )
             .instrument(tracing::error_span!("register_parquet"))

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -13,6 +13,10 @@
  * limitations under the License.
  */
 
+//! Implementation of MiniModelarDB's main function and a `Context` type that
+//! provides access to the system's configuration and components throughout the
+//! system.
+
 mod catalog;
 mod errors;
 mod ingestion;
@@ -41,14 +45,20 @@ use crate::tables::ModelTable;
 #[global_allocator]
 static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 
-/** Public Types **/
+/// Provides access to the system's configuration and components.
 pub struct Context {
+    /// Metadata for the tables and model tables in the data folder.
     catalog: Catalog,
+    /// A Tokio runtime for executing asynchronous tasks.
     runtime: Runtime,
+    /// Main interface for Apache Arrow DataFusion.
     session: SessionContext,
 }
 
-/** Public Functions **/
+/// Setup tracing, read table and model table metadata from the path given by
+/// the first command line argument, construct a `Context`, and start Apache
+/// Arrow Flight interface. Returns `Error` if the metadata cannot be read or
+/// the Apache Arrow Flight interface cannot be started.
 fn main() -> Result<(), String> {
     // A layer that logs events to stdout.
     let stdout_log = tracing_subscriber::fmt::layer();
@@ -59,16 +69,13 @@ fn main() -> Result<(), String> {
     if let Some(data_folder) = args.next() {
         // Build Context.
         let mut catalog = Catalog::try_new(&data_folder).map_err(|error| {
-            format!(
-                "Unable to read data folder {} due to {}",
-                &data_folder, &error
-            )
+            format!("Unable to read data folder '{}': {}", &data_folder, &error)
         })?;
         let runtime = Runtime::new().unwrap();
         let mut session = create_session_context();
 
         // Register Tables.
-        register_tables(&runtime, &mut session, &mut catalog);
+        register_tables_and_model_tables(&runtime, &mut session, &mut catalog);
 
         // Start Interface.
         let context = Arc::new(Context {
@@ -76,7 +83,7 @@ fn main() -> Result<(), String> {
             runtime,
             session,
         });
-        remote::start_arrow_flight_server(context, 9999);
+        remote::start_arrow_flight_server(context, 9999).map_err(|error| error.to_string())?
     } else {
         // The errors are consciously ignored as the program is terminating.
         let binary_path = std::env::current_exe().unwrap();
@@ -86,7 +93,12 @@ fn main() -> Result<(), String> {
     Ok(())
 }
 
-/** Private Functions **/
+/// Create a new `SessionContext` for interacting with Apache Arrow DataFusion.
+/// The `SessionContext` is constructed with the default configuration, default
+/// resource managers, the local file system as the only object store, and
+/// additional optimizer rules that rewrite simple aggregate queries to be
+/// executed directly on the models instead of on reconstructed data points for
+/// model tables.
 fn create_session_context() -> SessionContext {
     let config = SessionConfig::new();
     let runtime = Arc::new(RuntimeEnv::default());
@@ -96,35 +108,53 @@ fn create_session_context() -> SessionContext {
     SessionContext::with_state(state)
 }
 
-fn register_tables(runtime: &Runtime, session: &mut SessionContext, catalog: &mut Catalog) {
+/// Register all tables and model tables in `catalog` with Apache Arrow
+/// DataFusion through `session_context`. If initialization fails the table or
+/// model table is removed from `catalog`.
+fn register_tables_and_model_tables(
+    runtime: &Runtime,
+    session_context: &mut SessionContext,
+    catalog: &mut Catalog,
+) {
     // Initializes tables consisting of standard Apache Parquet files.
     catalog.table_metadata.retain(|table_metadata| {
-        let result = runtime.block_on(session.register_parquet(
+        let result = runtime.block_on(session_context.register_parquet(
             &table_metadata.name,
             &table_metadata.path,
             ParquetReadOptions::default(),
         ));
-        check_if_ok_otherwse_log_error("table", &table_metadata.name, result)
+        check_if_table_or_model_table_is_initialized_otherwise_log_error(
+            "table",
+            &table_metadata.name,
+            result,
+        )
     });
 
     // Initializes tables storing time series as models in Apache Parquet files.
     catalog.model_table_metadata.retain(|model_table_metadata| {
-        let result = session.register_table(
+        let result = session_context.register_table(
             model_table_metadata.name.as_str(),
             ModelTable::new(model_table_metadata),
         );
-        check_if_ok_otherwse_log_error("model table", &model_table_metadata.name, result)
+        check_if_table_or_model_table_is_initialized_otherwise_log_error(
+            "model table",
+            &model_table_metadata.name,
+            result,
+        )
     });
 }
 
-fn check_if_ok_otherwse_log_error<T>(
+/// Check if the `result`from a table or model table initialization is an
+/// `Error`, if so log an error message containing `table_type` and `name` and
+/// return `false`, otherwise return `true`.
+fn check_if_table_or_model_table_is_initialized_otherwise_log_error<T>(
     table_type: &str,
     name: &str,
     result: Result<T, DataFusionError>,
 ) -> bool {
     if result.is_err() {
         error!(
-            "Unable to initialize {} {} due to {}.",
+            "Unable to initialize {} '{}': {}",
             table_type,
             name,
             result.err().unwrap(),

--- a/server/src/remote.rs
+++ b/server/src/remote.rs
@@ -144,7 +144,7 @@ impl FlightService for FlightServiceHandler {
         &self,
         _request: Request<Criteria>,
     ) -> Result<Response<Self::ListFlightsStream>, Status> {
-        let table_names = self.context.catalog.table_names();
+        let table_names = self.context.catalog.table_and_model_table_names();
         let flight_descriptor = FlightDescriptor::new_path(table_names);
         let flight_info =
             FlightInfo::new(IpcMessage(vec![]), Some(flight_descriptor), vec![], -1, -1);

--- a/server/src/tables.rs
+++ b/server/src/tables.rs
@@ -78,7 +78,7 @@ impl ModelTable {
 
         Arc::new(ModelTable {
             model_table_metadata: model_table_metadata.clone(),
-            segment_folder_path: Path::from(model_table_metadata.segment_folder.clone()),
+            segment_folder_path: Path::from(model_table_metadata.segment_path.clone()),
             object_store_url: ObjectStoreUrl::local_filesystem(),
             schema: Arc::new(Schema::new(columns)),
         })
@@ -167,14 +167,14 @@ impl ModelTable {
 
         let df_schema = self
             .model_table_metadata
-            .segment_group_file_schema
+            .segment_file_legacy_schema
             .clone()
             .to_dfschema()?;
 
         let physical_predicate = planner::create_physical_expr(
             predicate,
             &df_schema,
-            &self.model_table_metadata.segment_group_file_schema,
+            &self.model_table_metadata.segment_file_legacy_schema,
             &ExecutionProps::new(),
         )?;
 
@@ -237,7 +237,7 @@ impl TableProvider for ModelTable {
         //TODO: partition and limit the number of rows read from the files properly
         let file_scan_config = FileScanConfig {
             object_store_url: self.object_store_url.clone(),
-            file_schema: self.model_table_metadata.segment_group_file_schema.clone(),
+            file_schema: self.model_table_metadata.segment_file_legacy_schema.clone(),
             file_groups: vec![partitioned_files],
             statistics,
             projection: None,


### PR DESCRIPTION
As the integration tests are not yet implemented, the code has been manually tested on Arch Linux, Ubuntu, and Windows 11. So for additional confirmation that the catalog is now compatible with Windows, please also manually check that tables are loaded and can be queried as expected. Finally, while some additional unit tests have been added, tests for functions and methods that operate on files were purposely not added to not duplicate work currently being done to effectively test IO in the storage engine.