### PR TITLE
Rename MiniModelarDB to ModelarDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,6 +1240,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "mdb"
+version = "0.1.0"
+dependencies = [
+ "arrow",
+ "arrow-flight",
+ "dirs",
+ "rustyline",
+ "serde_json",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "mdbd"
+version = "0.1.0"
+dependencies = [
+ "arrow-flight",
+ "async-trait",
+ "datafusion",
+ "datafusion-physical-expr",
+ "futures",
+ "log",
+ "object_store",
+ "paho-mqtt",
+ "proptest",
+ "snmalloc-rs",
+ "tokio",
+ "tonic",
+ "tracing",
+ "tracing-futures",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,40 +1304,6 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys",
-]
-
-[[package]]
-name = "mmdb"
-version = "0.1.0"
-dependencies = [
- "arrow",
- "arrow-flight",
- "dirs",
- "rustyline",
- "serde_json",
- "tokio",
- "tonic",
-]
-
-[[package]]
-name = "mmdbd"
-version = "0.1.0"
-dependencies = [
- "arrow-flight",
- "async-trait",
- "datafusion",
- "datafusion-physical-expr",
- "futures",
- "log",
- "object_store",
- "paho-mqtt",
- "proptest",
- "snmalloc-rs",
- "tokio",
- "tonic",
- "tracing",
- "tracing-futures",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ performance by representing time series using multiple different types of models
 such as constant and linear functions. These compressed time series can be
 efficiently queried using a relational interface and SQL without any knowledge
 about the model-based representation. A query optimizer automatically rewrites
-the queries to exploits the model-based representation.
+the queries to exploit the model-based representation.
 
 ModelarDB is designed to be cross-platform and is tested on Microsoft Windows,
 macOS, and Ubuntu. It is implemented in [Rust](https://www.rust-lang.org/) and

--- a/README.md
+++ b/README.md
@@ -1,22 +1,36 @@
-# MiniModelarDB
-MiniModelarDB is a model-based time series management system that is primarily
-built as a re-design and re-implementation of
-[ModelarDB](https://github.com/ModelarData/ModelarDB). It is implemented in
-[Rust](https://www.rust-lang.org/) and uses
-[DataFusion](https://github.com/apache/arrow-datafusion) as the query engine,
-[Apache Arrow](https://github.com/apache/arrow-rs) as the in-memory format, and
-[Apache Parquet](https://github.com/apache/arrow-rs) as the on-disk format. The
-primary goals of the project are to experiment with low-level optimizations
-that are not easily possible on the JVM, design methods for efficiently
-representing irregular time series using a model-based approach while only
-requiring users to specify an error bound, develop a query optimizer that
-allows queries to automatically exploit the model-based representation, and
-provide a single easy to use relational query interface. MiniModelarDB is
-designed for Unix-like operating systems and is tested on Linux.
+# ModelarDB
+ModelarDB is an efficient high-performance time series management system. It
+provides state-of-the-art lossless compression, lossy compression, and query
+performance by representing time series using multiple different types of models
+such as constant and linear functions. These compressed time series can be
+efficiently queried using a relational interface and SQL without any knowledge
+about the model-based representation. A query optimizer automatically rewrites
+the queries to exploits the model-based representation.
 
-MiniModelarDB intentionally does not gather usage data. So, all users are highly
+ModelarDB is designed to be cross-platform and is tested on Microsoft Windows,
+macOS, and Ubuntu. It is implemented in [Rust](https://www.rust-lang.org/) and
+uses [Apache Arrow
+Flight](https://github.com/apache/arrow-rs/tree/master/arrow-flight) for
+communicating with clients, [Apache Arrow
+DataFusion](https://github.com/apache/arrow-datafusion) as its query engine,
+[Apache Arrow](https://github.com/apache/arrow-rs) as its in-memory data format,
+and [Apache Parquet](https://github.com/apache/arrow-rs/tree/master/parquet) as
+its on-disk data format.
+
+The first prototype of ModelarDB was implemented using [Apache
+Spark](https://www.h2database.com/html/main.html), [Apache
+Cassandra](https://cassandra.apache.org/_/index.html), and
+[H2](https://www.h2database.com/html/main.html) and was developed as part of a
+[research project](https://github.com/skejserjensen/ModelarDB) at Aalborg
+University and later as an [open-source
+project](https://github.com/ModelarData/ModelarDB). While this JVM-based
+prototype validated the benefits of using a model-based representation for time
+series, it has been superseded by the much most efficient Rust-based
+implementation.
+
+ModelarDB intentionally does not gather usage data. So, all users are highly
 encouraged to post comments, suggestions, and bugs as GitHub issues, especially
-if a limitation of MiniModelarDB prevents it from being used in a particular domain.
+if a limitation of ModelarDB prevents it from being used in a particular domain.
 
 ## Installation
 ### Linux
@@ -44,9 +58,9 @@ The following commands are for Ubuntu Server. However, equivalent commands shoul
    * Debug Build: `cargo build`
    * Release Build: `cargo build --release`
    * Run Tests: `cargo test`
-   * Run Server: `cargo run --bin mmdbd path_to_data_folder`
-   * Run Client: `cargo run --bin mmdb [server_address] [query_file]`
-5. Move `mmdbd` and `mmdb` from the `target` directory to any directory.
+   * Run Server: `cargo run --bin mdbd path_to_data_folder`
+   * Run Client: `cargo run --bin mdb [server_address] [query_file]`
+5. Move `mdbd` and `mdb` from the `target` directory to any directory.
 
 ## Development
 All code must be formatted according to the [Rust Style Guide](https://github.com/rust-dev-tools/fmt-rfcs/blob/master/guide/guide.md)
@@ -72,8 +86,8 @@ used for purposes such as logging, where multiple crates provide similar functio
 - Property-based Testing - [proptest](https://crates.io/crates/proptest)
 
 ## Contributions
-Contributions to all aspects of MiniModelarDB are highly appreciated and do not
-need to be in the form of code. For example, contributions can be:
+Contributions to all aspects of ModelarDB are highly appreciated and do not need
+to be in the form of code. For example, contributions can be:
 
 - Helping other users.
 - Writing documentation.
@@ -88,5 +102,5 @@ in the appropriate GitHub issue if one exists, e.g., the bug report if it is a
 bugfix, and as a new GitHub issue otherwise.
 
 ## License
-MiniModelarDB is licensed under version 2.0 of the Apache License and a copy of the
+ModelarDB is licensed under version 2.0 of the Apache License and a copy of the
 license is bundled with the program.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Cassandra](https://cassandra.apache.org/_/index.html), and
 University and later as an [open-source
 project](https://github.com/ModelarData/ModelarDB). While this JVM-based
 prototype validated the benefits of using a model-based representation for time
-series, it has been superseded by the much most efficient Rust-based
+series, it has been superseded by this much more efficient Rust-based
 implementation.
 
 ModelarDB intentionally does not gather usage data. So, all users are highly

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mmdb"
+name = "mdb"
 version = "0.1.0"
 license = "Apache-2.0"
 edition = "2021"

--- a/client/src/helper.rs
+++ b/client/src/helper.rs
@@ -1,4 +1,4 @@
-/* Copyright 2022 The MiniModelarDB Contributors
+/* Copyright 2022 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,4 +1,4 @@
-/* Copyright 2021 The MiniModelarDB Contributors
+/* Copyright 2021 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,7 +137,7 @@ fn repl(rt: Runtime, mut fsc: FlightServiceClient<Channel>) -> Result<()> {
     let mut editor = Editor::<ClientHelper>::new()?;
     let table_names = retrieve_table_names(&rt, &mut fsc)?;
     editor.set_helper(Some(ClientHelper::new(table_names)));
-    let history_file_name = ".mmdbc_history";
+    let history_file_name = ".mdb_history";
     if let Some(mut home) = dirs::home_dir() {
         home.push(history_file_name);
         let _ = editor.load_history(&home);

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mmdbd"
+name = "mdbd"
 version = "0.1.0"
 license = "Apache-2.0"
 edition = "2021"

--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -1,4 +1,4 @@
-/* Copyright 2021 The MiniModelarDB Contributors
+/* Copyright 2021 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/errors.rs
+++ b/server/src/errors.rs
@@ -1,4 +1,4 @@
-/* Copyright 2022 The MiniModelarDB Contributors
+/* Copyright 2022 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,17 +25,17 @@ use std::fmt::{Display, Formatter};
 
 /// Error type used throughout the system.
 #[derive(Debug)]
-pub enum MiniModelarDBError {
+pub enum ModelarDBError {
     /// Error returned by the model types.
     CompressionError(String),
 }
 
-impl Error for MiniModelarDBError {}
+impl Error for ModelarDBError {}
 
-impl Display for MiniModelarDBError {
+impl Display for ModelarDBError {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-	match self {
-	    MiniModelarDBError::CompressionError(reason) => write!(f, "Compression Error: {}", reason),
-	}
+        match self {
+            ModelarDBError::CompressionError(reason) => write!(f, "Compression Error: {}", reason),
+        }
     }
 }

--- a/server/src/ingestion.rs
+++ b/server/src/ingestion.rs
@@ -1,4 +1,4 @@
-/* Copyright 2022 The MiniModelarDB Contributors
+/* Copyright 2022 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/macros.rs
+++ b/server/src/macros.rs
@@ -1,4 +1,4 @@
-/* Copyright 2022 The MiniModelarDB Contributors
+/* Copyright 2022 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,4 +1,4 @@
-/* Copyright 2021 The MiniModelarDB Contributors
+/* Copyright 2021 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-//! Implementation of MiniModelarDB's main function and a `Context` type that
+//! Implementation of ModelarDB's main function and a `Context` type that
 //! provides access to the system's configuration and components throughout the
 //! system.
 

--- a/server/src/models/gorilla.rs
+++ b/server/src/models/gorilla.rs
@@ -1,4 +1,4 @@
-/* Copyright 2021 The MiniModelarDB Contributors
+/* Copyright 2021 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/models/mod.rs
+++ b/server/src/models/mod.rs
@@ -1,4 +1,4 @@
-/* Copyright 2021 The MiniModelarDB Contributors
+/* Copyright 2021 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ use std::cmp::{Ordering, PartialOrd};
 
 use datafusion::arrow::array::{Int32Array, Int64Array};
 
-use crate::errors::MiniModelarDBError;
+use crate::errors::ModelarDBError;
 use crate::types::{
     TimeSeriesId, TimeSeriesIdArray, TimeSeriesIdBuilder, Timestamp, TimestampBuilder, Value,
     ValueBuilder,
@@ -50,9 +50,9 @@ struct ErrorBound(f32);
 impl ErrorBound {
     /// Return `ErrorBound` if `error_bound` is a positive finite value,
     /// otherwise `CompressionError`.
-    fn try_new(error_bound: f32) -> Result<Self, MiniModelarDBError> {
+    fn try_new(error_bound: f32) -> Result<Self, ModelarDBError> {
         if error_bound < 0.0 || error_bound.is_infinite() || error_bound.is_nan() {
-            Err(MiniModelarDBError::CompressionError(
+            Err(ModelarDBError::CompressionError(
                 "Error bound cannot be negative, infinite, or NAN.".to_owned(),
             ))
         } else {

--- a/server/src/models/pmcmean.rs
+++ b/server/src/models/pmcmean.rs
@@ -1,4 +1,4 @@
-/* Copyright 2021 The MiniModelarDB Contributors
+/* Copyright 2021 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/models/swing.rs
+++ b/server/src/models/swing.rs
@@ -1,4 +1,4 @@
-/* Copyright 2021 The MiniModelarDB Contributors
+/* Copyright 2021 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/optimizer/mod.rs
+++ b/server/src/optimizer/mod.rs
@@ -1,4 +1,4 @@
-/* Copyright 2021 The MiniModelarDB Contributors
+/* Copyright 2021 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/optimizer/model_simple_aggregates.rs
+++ b/server/src/optimizer/model_simple_aggregates.rs
@@ -1,4 +1,4 @@
-/* Copyright 2021 The MiniModelarDB Contributors
+/* Copyright 2021 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/remote.rs
+++ b/server/src/remote.rs
@@ -1,4 +1,4 @@
-/* Copyright 2021 The MiniModelarDB Contributors
+/* Copyright 2021 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/storage/data_point.rs
+++ b/server/src/storage/data_point.rs
@@ -1,4 +1,4 @@
-/* Copyright 2022 The MiniModelarDB Contributors
+/* Copyright 2022 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -1,4 +1,4 @@
-/* Copyright 2022 The MiniModelarDB Contributors
+/* Copyright 2022 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/storage/segment.rs
+++ b/server/src/storage/segment.rs
@@ -1,4 +1,4 @@
-/* Copyright 2022 The MiniModelarDB Contributors
+/* Copyright 2022 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/storage/time_series.rs
+++ b/server/src/storage/time_series.rs
@@ -1,4 +1,4 @@
-/* Copyright 2022 The MiniModelarDB Contributors
+/* Copyright 2022 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/tables.rs
+++ b/server/src/tables.rs
@@ -1,4 +1,4 @@
-/* Copyright 2021 The MiniModelarDB Contributors
+/* Copyright 2021 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -1,4 +1,4 @@
-/* Copyright 2022 The MiniModelarDB Contributors
+/* Copyright 2022 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR should replace all instances of "MiniModelarDB" with "ModelarDB", "mmdbd" with "mdbd", and "mmdb" with "mdb" in preparation for renaming this repository to `ModelarDB-RS`. The README has also been updated to make it clear that this is the primary version of ModelarDB and that it superseeds the old [JVM-based](https://github.com/skejserjensen/ModelarDB) [version](https://github.com/ModelarData/ModelarDB). 